### PR TITLE
[FEAT] Add product repository, pagination, and seeding script

### DIFF
--- a/beland-backend/package.json
+++ b/beland-backend/package.json
@@ -17,7 +17,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "seed:products": "ts-node -r tsconfig-paths/register src/products/scripts/load-mock-products.ts"
   },
   "dependencies": {
     "@nestjs/cache-manager": "^3.0.1",

--- a/beland-backend/src/app.module.ts
+++ b/beland-backend/src/app.module.ts
@@ -1,5 +1,5 @@
 // src/app.module.ts
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import {
@@ -27,6 +27,7 @@ import { WalletsModule } from './wallets/wallets.module';
 import { DatabaseModule } from './database/database.module';
 import { DataSourceOptions } from 'typeorm';
 import typeormConfig from './config/typeorm';
+import { RequestLoggerMiddleware } from './middlleware/request-logger.middleware';
 
 @Module({
   imports: [
@@ -85,4 +86,8 @@ import typeormConfig from './config/typeorm';
     },
   ],
 })
-export class AppModule {}
+export class AppModule implements NestModule{
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(RequestLoggerMiddleware).forRoutes('*');
+  }
+}

--- a/beland-backend/src/main.ts
+++ b/beland-backend/src/main.ts
@@ -4,7 +4,7 @@ import { AppModule } from './app.module';
 import { ValidationPipe, Logger, LogLevel } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { HttpExceptionFilter } from './common/filters/http-exception.filter';
-import { RequestLoggerMiddleware } from './middlleware/request-logger.middleware';
+// import { RequestLoggerMiddleware } from './middlleware/request-logger.middleware';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
@@ -16,7 +16,7 @@ async function bootstrap() {
 
   app.setGlobalPrefix('api');
   app.useGlobalFilters(new HttpExceptionFilter());
-  app.use(RequestLoggerMiddleware);
+  // app.use(RequestLoggerMiddleware);
   app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true,

--- a/beland-backend/src/products/data/mock-products.json
+++ b/beland-backend/src/products/data/mock-products.json
@@ -1,0 +1,149 @@
+[
+  {
+    "name": "Agua Mineral EcoBottle",
+    "description": "Agua mineral embotellada en envase 100% reciclable.",
+    "price": 30,
+    "image_url": "https://cdn.example.com/products/agua-eco.jpg",
+    "category": "Bebidas"
+  },
+  {
+    "name": "Té Verde Orgánico",
+    "description": "Té verde frío sin azúcar, con antioxidantes naturales.",
+    "price": 50,
+    "image_url": "https://cdn.example.com/products/te-verde.jpg",
+    "category": "Bebidas"
+  },
+  {
+    "name": "Jugo Natural de Naranja",
+    "description": "Exprimido 100%, sin conservantes ni azúcar añadida.",
+    "price": 60,
+    "image_url": "https://cdn.example.com/products/jugo-naranja.jpg",
+    "category": "Bebidas"
+  },
+  {
+    "name": "Kombucha Artesanal",
+    "description": "Fermentado natural, sabor a frutos rojos.",
+    "price": 90,
+    "image_url": "https://cdn.example.com/products/kombucha.jpg",
+    "category": "Bebidas"
+  },
+  {
+    "name": "Café Frío Orgánico",
+    "description": "Cold brew sin azúcar, 100% café colombiano.",
+    "price": 70,
+    "image_url": "https://cdn.example.com/products/cafe-frio.jpg",
+    "category": "Bebidas"
+  },
+  {
+    "name": "Smoothie de Mango",
+    "description": "Batido natural de mango y avena, sin lactosa.",
+    "price": 85,
+    "image_url": "https://cdn.example.com/products/smoothie-mango.jpg",
+    "category": "Bebidas"
+  },
+  {
+    "name": "Limonada con Menta",
+    "description": "Refrescante y natural, sin gas.",
+    "price": 45,
+    "image_url": "https://cdn.example.com/products/limonada-menta.jpg",
+    "category": "Bebidas"
+  },
+  {
+    "name": "Bebida de Coco",
+    "description": "Agua de coco natural, sin azúcares añadidos.",
+    "price": 60,
+    "image_url": "https://cdn.example.com/products/agua-coco.jpg",
+    "category": "Bebidas"
+  },
+  {
+    "name": "Bebida Energética Natural",
+    "description": "Con guaraná y yerba mate. Sin químicos.",
+    "price": 95,
+    "image_url": "https://cdn.example.com/products/bebida-energetica.jpg",
+    "category": "Bebidas"
+  },
+  {
+    "name": "Leche de Almendras",
+    "description": "Bebida vegetal sin lactosa, con calcio añadido.",
+    "price": 55,
+    "image_url": "https://cdn.example.com/products/leche-almendra.jpg",
+    "category": "Bebidas"
+  },
+  {
+    "name": "Chips de Plátano",
+    "description": "Crujientes y horneados, sin aditivos.",
+    "price": 40,
+    "image_url": "https://cdn.example.com/products/chips-platano.jpg",
+    "category": "Snacks"
+  },
+  {
+    "name": "Mix de Frutos Secos",
+    "description": "Almendras, nueces y arándanos. Energía natural.",
+    "price": 70,
+    "image_url": "https://cdn.example.com/products/frutos-secos.jpg",
+    "category": "Snacks"
+  },
+  {
+    "name": "Barras de Avena y Miel",
+    "description": "Empaque compostable. Sin azúcar refinada.",
+    "price": 55,
+    "image_url": "https://cdn.example.com/products/barra-avena.jpg",
+    "category": "Snacks"
+  },
+  {
+    "name": "Galletas de Quinoa",
+    "description": "Ricas en fibra, sin gluten.",
+    "price": 50,
+    "image_url": "https://cdn.example.com/products/galletas-quinoa.jpg",
+    "category": "Snacks"
+  },
+  {
+    "name": "Palomitas Naturales",
+    "description": "Con sal marina, sin aceites procesados.",
+    "price": 35,
+    "image_url": "https://cdn.example.com/products/palomitas.jpg",
+    "category": "Snacks"
+  },
+  {
+    "name": "Trozos de Coco Deshidratado",
+    "description": "Snack dulce natural, sin azúcar añadida.",
+    "price": 45,
+    "image_url": "https://cdn.example.com/products/coco-deshidratado.jpg",
+    "category": "Snacks"
+  },
+  {
+    "name": "Brownie Vegano",
+    "description": "Hecho con cacao puro y dátiles.",
+    "price": 60,
+    "image_url": "https://cdn.example.com/products/brownie.jpg",
+    "category": "Snacks"
+  },
+  {
+    "name": "Granola Crunch",
+    "description": "Avena, semillas y miel orgánica.",
+    "price": 65,
+    "image_url": "https://cdn.example.com/products/granola.jpg",
+    "category": "Snacks"
+  },
+  {
+    "name": "Chocobites sin Azúcar",
+    "description": "Pequeños bocados de chocolate 70%.",
+    "price": 75,
+    "image_url": "https://cdn.example.com/products/chocobites.jpg",
+    "category": "Snacks"
+  },
+  {
+    "name": "Tiras de Manzana Deshidratada",
+    "description": "Crujientes y dulces. 100% naturales.",
+    "price": 50,
+    "image_url": "https://cdn.example.com/products/manzana-deshidratada.jpg",
+    "category": "Snacks"
+  },
+  {
+    "name": "Chips de Kale",
+    "description": "Vegetales crujientes horneados, sin fritura.",
+    "price": 60,
+    "image_url": "https://cdn.example.com/products/chips-kale.jpg",
+    "category": "Snacks"
+  }
+]

--- a/beland-backend/src/products/entities/product.entity.ts
+++ b/beland-backend/src/products/entities/product.entity.ts
@@ -6,7 +6,8 @@ import {
   CreateDateColumn,
   OneToMany,
 } from 'typeorm';
-import { InventoryItem } from 'src/inventory-items/entities/inventory-item.entity';
+// import { InventoryItem } from 'src/inventory-items/entities/inventory-item.entity';
+import { InventoryItem } from '../../inventory-items/entities/inventory-item.entity';
 import { OrderItem } from 'src/order-items/entities/order-item.entity';
 import { RecycledItem } from 'src/recycled-items/entities/recycled-item.entity';
 

--- a/beland-backend/src/products/products.controller.ts
+++ b/beland-backend/src/products/products.controller.ts
@@ -1,34 +1,78 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  HttpCode,
+  HttpStatus,
+  Query,
+  Logger,
+} from '@nestjs/common';
 import { ProductsService } from './products.service';
 import { CreateProductDto } from './dto/create-product.dto';
 import { UpdateProductDto } from './dto/update-product.dto';
+import { PaginationDto } from 'src/common/dto/pagination.dto';
+import { OrderDto } from 'src/common/dto/order.dto';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiQuery,
+} from '@nestjs/swagger';
 
+@ApiTags('products')
 @Controller('products')
 export class ProductsController {
+  private readonly logger = new Logger(ProductsController.name);
+
   constructor(private readonly productsService: ProductsService) {}
 
   @Post()
-  create(@Body() createProductDto: CreateProductDto) {
-    return this.productsService.create(createProductDto);
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Crear nuevo producto' })
+  @ApiResponse({ status: 201, description: 'Producto creado exitosamente.' })
+  async create(@Body() dto: CreateProductDto) {
+    return this.productsService.create(dto);
   }
 
   @Get()
-  findAll() {
-    return this.productsService.findAll();
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Listar productos con paginación y ordenamiento' })
+  @ApiQuery({ name: 'page', required: false })
+  @ApiQuery({ name: 'limit', required: false })
+  @ApiQuery({ name: 'sortBy', required: false })
+  @ApiQuery({ name: 'order', required: false })
+  @ApiQuery({ name: 'category', required: false })
+  async findAll(
+    @Query() pagination: PaginationDto,
+    @Query() order: OrderDto,
+    @Query('category') category?: string,
+  ) {
+    return this.productsService.findAll(pagination, order, category);
   }
 
   @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.productsService.findOne(+id);
+  @HttpCode(HttpStatus.OK)
+  @ApiParam({ name: 'id', description: 'UUID del producto' })
+  async findOne(@Param('id') id: string) {
+    return this.productsService.findOne(id);
   }
 
   @Patch(':id')
-  update(@Param('id') id: string, @Body() updateProductDto: UpdateProductDto) {
-    return this.productsService.update(+id, updateProductDto);
+  @HttpCode(HttpStatus.OK)
+  @ApiParam({ name: 'id', description: 'UUID del producto' })
+  async update(@Param('id') id: string, @Body() dto: UpdateProductDto) {
+    return this.productsService.update(id, dto);
   }
 
   @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.productsService.remove(+id);
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiParam({ name: 'id', description: 'UUID del producto' })
+  async remove(@Param('id') id: string) {
+    await this.productsService.remove(id);
   }
 }

--- a/beland-backend/src/products/products.module.ts
+++ b/beland-backend/src/products/products.module.ts
@@ -1,9 +1,13 @@
 import { Module } from '@nestjs/common';
 import { ProductsService } from './products.service';
 import { ProductsController } from './products.controller';
+import { ProductRepository } from './products.repository';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Product } from './entities/product.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Product])],
   controllers: [ProductsController],
-  providers: [ProductsService],
+  providers: [ProductsService, ProductRepository],
 })
 export class ProductsModule {}

--- a/beland-backend/src/products/products.repository.ts
+++ b/beland-backend/src/products/products.repository.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { Product } from './entities/product.entity';
+import { PaginationDto } from 'src/common/dto/pagination.dto';
+import { OrderDto } from 'src/common/dto/order.dto';
+
+@Injectable()
+export class ProductRepository extends Repository<Product> {
+  constructor(private dataSource: DataSource) {
+    super(Product, dataSource.createEntityManager());
+  }
+
+  async findById(id: string): Promise<Product | null> {
+    return this.findOne({ where: { id } });
+  }
+
+  async findByName(name: string): Promise<Product | null> {
+    return this.createQueryBuilder('product')
+      .where('LOWER(product.name) = LOWER(:name)', { name })
+      .getOne();
+  }
+
+  async findAllPaginated(
+    pagination: PaginationDto,
+    order: OrderDto,
+    category?: string,
+  ): Promise<{
+    products: Product[];
+    total: number;
+    page: number;
+    limit: number;
+  }> {
+    const { page = 1, limit = 10 } = pagination;
+    const { sortBy = 'created_at', order: orderDir = 'DESC' } = order;
+
+    const query = this.createQueryBuilder('product');
+
+    if (category) {
+      query.andWhere('LOWER(product.category) = LOWER(:category)', {
+        category,
+      });
+    }
+
+    query.orderBy(`product.${sortBy}`, orderDir);
+    query.skip((page - 1) * limit).take(limit);
+
+    const [products, total] = await query.getManyAndCount();
+
+    return { products, total, page, limit };
+  }
+}

--- a/beland-backend/src/products/products.service.ts
+++ b/beland-backend/src/products/products.service.ts
@@ -1,26 +1,49 @@
-import { Injectable } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  ConflictException,
+  Logger,
+} from '@nestjs/common';
 import { CreateProductDto } from './dto/create-product.dto';
 import { UpdateProductDto } from './dto/update-product.dto';
+import { ProductRepository } from './products.repository';
+import { PaginationDto } from 'src/common/dto/pagination.dto';
+import { OrderDto } from 'src/common/dto/order.dto';
 
 @Injectable()
 export class ProductsService {
-  create(createProductDto: CreateProductDto) {
-    return 'This action adds a new product';
+  private readonly logger = new Logger(ProductsService.name);
+
+  constructor(private readonly repo: ProductRepository) {}
+
+  async create(dto: CreateProductDto) {
+    const exists = await this.repo.findByName(dto.name);
+    if (exists) {
+      throw new ConflictException(`El producto "${dto.name}" ya existe.`);
+    }
+
+    const newProduct = this.repo.create(dto);
+    return await this.repo.save(newProduct);
   }
 
-  findAll() {
-    return `This action returns all products`;
+  async findAll(pagination: PaginationDto, order: OrderDto, category?: string) {
+    return this.repo.findAllPaginated(pagination, order, category);
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} product`;
+  async findOne(id: string) {
+    const product = await this.repo.findById(id);
+    if (!product) throw new NotFoundException('Producto no encontrado');
+    return product;
   }
 
-  update(id: number, updateProductDto: UpdateProductDto) {
-    return `This action updates a #${id} product`;
+  async update(id: string, dto: UpdateProductDto) {
+    const product = await this.findOne(id);
+    Object.assign(product, dto);
+    return this.repo.save(product);
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} product`;
+  async remove(id: string) {
+    const product = await this.findOne(id);
+    await this.repo.remove(product);
   }
 }

--- a/beland-backend/src/products/scripts/load-mock-products.ts
+++ b/beland-backend/src/products/scripts/load-mock-products.ts
@@ -1,0 +1,35 @@
+import { NestFactory } from '@nestjs/core';
+import { ProductsService } from '../products.service';
+import { CreateProductDto } from '../dto/create-product.dto';
+import * as fs from 'fs';
+import * as path from 'path';
+import { AppModule } from 'src/app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.createApplicationContext(AppModule);
+  const productService = app.get(ProductsService);
+
+  const filePath = path.join(__dirname, '../data/mock-products.json');
+  const fileContent = fs.readFileSync(filePath, 'utf8');
+  const products: CreateProductDto[] = JSON.parse(fileContent);
+
+  for (const product of products) {
+    try {
+      await productService.create(product);
+      console.log(`✅ Producto creado: ${product.name}`);
+    } catch (error) {
+      if (error instanceof Error) {
+        console.warn(
+          `⚠️  No se pudo crear: ${product.name} - ${error.message}`,
+        );
+      } else {
+        console.warn(
+          `⚠️  No se pudo crear: ${product.name} - error desconocido`,
+        );
+      }
+    }
+  }
+
+  await app.close();
+}
+void bootstrap();


### PR DESCRIPTION
Introduces a custom ProductRepository with paginated and filtered queries, updates the ProductsService and ProductsController to support pagination, ordering, and category filtering, and adds OpenAPI documentation. Adds a script and mock data for seeding products, and registers a new CLI command for seeding. Also refactors imports and middleware application for improved maintainability.