### PR TITLE
[FIX] Add Auth0 user creation and user service exports

### DIFF
--- a/beland-backend/env.example
+++ b/beland-backend/env.example
@@ -1,0 +1,25 @@
+# Database Configuration
+DB_HOST=localhost
+DB_PORT=5432
+DB_USERNAME=postgres
+DB_PASSWORD=your_password
+DB_DATABASE=beland_db
+
+# Auth0 Configuration
+AUTH0_DOMAIN=your-domain.auth0.com
+AUTH0_AUDIENCE=your-api-identifier
+AUTH0_CLIENT_ID=your-client-id
+AUTH0_CLIENT_SECRET=your-client-secret
+AUTH0_NAMESPACE=https://your-domain.auth0.com/
+
+# Auth0 Management API (Optional - for advanced features)
+AUTH0_MANAGEMENT_CLIENT_ID=your-management-client-id
+AUTH0_MANAGEMENT_CLIENT_SECRET=your-management-client-secret
+
+# JWT Configuration
+JWT_SECRET=your-jwt-secret
+JWT_EXPIRES_IN=1d
+
+# Application Configuration
+PORT=3000
+NODE_ENV=development 

--- a/beland-backend/src/users/users.module.ts
+++ b/beland-backend/src/users/users.module.ts
@@ -9,5 +9,6 @@ import { User } from './entities/users.entity';
   imports: [TypeOrmModule.forFeature([User])],
   controllers: [UsersController],
   providers: [UsersService, UsersRepository],
+  exports: [UsersService],
 })
 export class UsersModule {}

--- a/beland-backend/src/users/users.repository.ts
+++ b/beland-backend/src/users/users.repository.ts
@@ -16,6 +16,16 @@ export class UsersRepository {
     return await this.usersRepository.save(user);
   }
 
+  async findByEmail(email: string) {
+    return await this.usersRepository.findOne({ where: { email } });
+  }
+
+  async createInitialUser(createUserDto: CreateUserDto) {
+    const user = this.usersRepository.create(createUserDto);
+    return await this.usersRepository.save(user);
+  }
+
+
   async findAll(page: number = 1, limit: number = 10) {
     let users = await this.usersRepository.find()
 

--- a/beland-backend/src/users/users.service.ts
+++ b/beland-backend/src/users/users.service.ts
@@ -11,6 +11,14 @@ export class UsersService {
     return await this.usersRepository.create(createUserDto);
   }
 
+  async findByEmail(email: string) {
+    return await this.usersRepository.findByEmail(email);
+  }
+
+  async createInitialUser(createUserDto: CreateUserDto) {
+    return await this.usersRepository.createInitialUser(createUserDto);
+  }
+
   async findAll(page: number = 1, limit: number = 10) {
     return await this.usersRepository.findAll(page, limit);
   }


### PR DESCRIPTION
Introduces support for creating users from Auth0 payloads in the JWT strategy by mapping Auth0 fields to the CreateUserDto. Adds createInitialUser and findByEmail methods to the users repository and service. Also exports UsersService from the users module for use in other modules.