### PR TITLE
[FEAT] Add admins module with permissions and guards

### DIFF
--- a/beland-backend/src/admins/admins.controller.spec.ts
+++ b/beland-backend/src/admins/admins.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdminsController } from './admins.controller';
+import { AdminsService } from './admins.service';
+
+describe('AdminsController', () => {
+  let controller: AdminsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AdminsController],
+      providers: [AdminsService],
+    }).compile();
+
+    controller = module.get<AdminsController>(AdminsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/beland-backend/src/admins/admins.controller.ts
+++ b/beland-backend/src/admins/admins.controller.ts
@@ -1,0 +1,188 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { AdminService } from './admins.service';
+import { CreateAdminDto } from './dto/create-admin.dto';
+import { UpdateAdminDto } from './dto/update-admin.dto';
+import { AdminDto } from './dto/admin.dto';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+import { RolesGuard } from 'src/auth/guards/roles.guard';
+import { Roles } from 'src/auth/decorators/roles.decorator';
+import { PermissionsGuard } from 'src/auth/guards/permissions.guard';
+import { RequiredPermissions } from 'src/auth/decorators/permissions.decorator';
+
+@ApiTags('admins')
+@Controller('admins')
+// @UseGuards(JwtAuthGuard, RolesGuard, PermissionsGuard)
+export class AdminsController {
+  constructor(private readonly adminsService: AdminService) {}
+
+  @Post()
+  // @Roles('SUPERADMIN')
+  // @RequiredPermissions('user_permission')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: 'Crear una nueva entrada de administrador',
+    description:
+      'Asigna el rol de "admin" a un usuario existente y define sus permisos administrativos. Solo accesible por un **Superadmin** con permiso de gestión de usuarios.',
+  })
+  //@ApiBearerAuth('JWT-auth')
+  @ApiResponse({
+    status: 201,
+    description: 'Administrador creado exitosamente.',
+    type: AdminDto,
+  })
+  @ApiResponse({ status: 400, description: 'Datos de entrada inválidos.' })
+  @ApiResponse({
+    status: 401,
+    description: 'No autenticado (token inválido o ausente).',
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'No autorizado (rol o permiso insuficiente).',
+  })
+  @ApiResponse({ status: 404, description: 'Usuario a asignar no encontrado.' })
+  @ApiResponse({
+    status: 409,
+    description: 'El usuario ya es un administrador.',
+  })
+  async create(@Body() createAdminDto: CreateAdminDto): Promise<AdminDto> {
+    return this.adminsService.create(createAdminDto);
+  }
+
+  @Get()
+  @Roles('ADMIN', 'SUPERADMIN')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Obtener la lista de todos los administradores',
+    description:
+      'Lista todos los usuarios que tienen una entrada en la tabla de administradores. Accesible por **Admin** y **Superadmin**.',
+  })
+  // @ApiBearerAuth('JWT-auth')
+  @ApiResponse({
+    status: 200,
+    description: 'Lista de administradores.',
+    type: [AdminDto],
+  })
+  @ApiResponse({ status: 401, description: 'No autenticado.' })
+  @ApiResponse({
+    status: 403,
+    description: 'No autorizado (rol insuficiente).',
+  })
+  async findAll(): Promise<AdminDto[]> {
+    return this.adminsService.findAll();
+  }
+
+  @Get(':admin_id')
+  @Roles('ADMIN', 'SUPERADMIN')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Obtener un administrador por su ID',
+    description:
+      'Recupera los detalles de un administrador específico. Accesible por **Admin** y **Superadmin**.',
+  })
+  // @ApiBearerAuth('JWT-auth')
+  @ApiParam({
+    name: 'admin_id',
+    description: 'ID único del administrador',
+    type: String,
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Administrador encontrado.',
+    type: AdminDto,
+  })
+  @ApiResponse({ status: 401, description: 'No autenticado.' })
+  @ApiResponse({
+    status: 403,
+    description: 'No autorizado (rol insuficiente).',
+  })
+  @ApiResponse({ status: 404, description: 'Administrador no encontrado.' })
+  async findOne(@Param('admin_id') admin_id: string): Promise<AdminDto> {
+    return this.adminsService.findOne(admin_id);
+  }
+
+  @Patch(':admin_id')
+  @Roles('SUPERADMIN')
+  @RequiredPermissions('user_permission')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Actualizar los permisos de un administrador',
+    description:
+      'Modifica los permisos de un administrador existente (contenido, usuarios, moderación, finanzas, analíticas, configuraciones, gestión de líderes y empresas). Solo accesible por un **Superadmin** con permiso de gestión de usuarios.',
+  })
+  // @ApiBearerAuth('JWT-auth')
+  @ApiParam({
+    name: 'admin_id',
+    description: 'ID único del administrador a actualizar',
+    type: String,
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Administrador actualizado exitosamente.',
+    type: AdminDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description:
+      'Datos de entrada inválidos (ej. intentar cambiar el user_id).',
+  })
+  @ApiResponse({ status: 401, description: 'No autenticado.' })
+  @ApiResponse({
+    status: 403,
+    description: 'No autorizado (rol o permiso insuficiente).',
+  })
+  @ApiResponse({ status: 404, description: 'Administrador no encontrado.' })
+  async update(
+    @Param('admin_id') admin_id: string,
+    @Body() updateAdminDto: UpdateAdminDto,
+  ): Promise<AdminDto> {
+    return this.adminsService.update(admin_id, updateAdminDto);
+  }
+
+  @Delete(':admin_id')
+  @Roles('SUPERADMIN')
+  @RequiredPermissions('user_permission')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary:
+      'Eliminar una entrada de administrador y resetear el rol del usuario',
+    description:
+      'Elimina la entrada de un administrador de la tabla de "admins" y automáticamente revierte el rol del usuario asociado a "USER". Solo accesible por un **Superadmin** con permiso de gestión de usuarios.',
+  })
+  // @ApiBearerAuth('JWT-auth')
+  @ApiParam({
+    name: 'admin_id',
+    description: 'ID único del administrador a eliminar',
+    type: String,
+  })
+  @ApiResponse({
+    status: 204,
+    description: 'Administrador eliminado exitosamente.',
+  })
+  @ApiResponse({ status: 401, description: 'No autenticado.' })
+  @ApiResponse({
+    status: 403,
+    description: 'No autorizado (rol o permiso insuficiente).',
+  })
+  @ApiResponse({ status: 404, description: 'Administrador no encontrado.' })
+  async remove(@Param('admin_id') admin_id: string): Promise<void> {
+    await this.adminsService.remove(admin_id);
+  }
+}

--- a/beland-backend/src/admins/admins.module.ts
+++ b/beland-backend/src/admins/admins.module.ts
@@ -1,0 +1,20 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Admin } from './entities/admin.entity';
+import { AdminsController } from './admins.controller';
+import { AdminService } from './admins.service';
+import { AdminRepository } from './admins.repository';
+import { UsersModule } from '../users/users.module';
+import { RolesModule } from '../roles/roles.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Admin]),
+    forwardRef(() => UsersModule),
+    RolesModule,
+  ],
+  controllers: [AdminsController],
+  providers: [AdminService, AdminRepository],
+  exports: [AdminService, AdminRepository],
+})
+export class AdminsModule {}

--- a/beland-backend/src/admins/admins.repository.ts
+++ b/beland-backend/src/admins/admins.repository.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, Repository, DeleteResult } from 'typeorm';
+import { Admin } from './entities/admin.entity';
+import { User } from '../users/entities/users.entity';
+
+@Injectable()
+export class AdminRepository extends Repository<Admin> {
+  constructor(private dataSource: DataSource) {
+    super(Admin, dataSource.createEntityManager());
+  }
+
+  async findOneByAdminId(admin_id: string): Promise<Admin | null> {
+    return this.findOne({
+      where: { admin_id },
+      relations: ['user'],
+    });
+  }
+
+  // user_id ahora es el ID (UUID) del usuario
+  async findByUserId(user_id: string): Promise<Admin | null> {
+    return this.findOne({
+      where: { user_id },
+      relations: ['user'],
+    });
+  }
+
+  async findAll(): Promise<Admin[]> {
+    return this.find({ relations: ['user'] });
+  }
+
+  async removeByAdminId(admin_id: string): Promise<DeleteResult> {
+    return this.delete({ admin_id });
+  }
+
+  // user_id ahora es el ID (UUID) del usuario
+  async removeByUserId(user_id: string): Promise<DeleteResult> {
+    return this.delete({ user_id });
+  }
+}

--- a/beland-backend/src/admins/admins.service.spec.ts
+++ b/beland-backend/src/admins/admins.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdminsService } from './admins.service';
+
+describe('AdminsService', () => {
+  let service: AdminsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AdminsService],
+    }).compile();
+
+    service = module.get<AdminsService>(AdminsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/beland-backend/src/admins/admins.service.ts
+++ b/beland-backend/src/admins/admins.service.ts
@@ -1,0 +1,466 @@
+// src/admins/admins.service.ts
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  ConflictException,
+  Inject,
+  forwardRef,
+  Logger,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { Admin } from './entities/admin.entity';
+import { CreateAdminDto } from './dto/create-admin.dto';
+import { UpdateAdminDto } from './dto/update-admin.dto';
+import { UsersService } from '../users/users.service';
+import { AdminRepository } from './admins.repository';
+import { QueryRunner, DeleteResult, Repository, Not } from 'typeorm';
+import { RolesRepository } from '../roles/roles.repository';
+import { User } from '../users/entities/users.entity';
+import { plainToInstance } from 'class-transformer';
+
+// Definición de tipo para todos los roles válidos
+type ValidRoleNames = 'USER' | 'LEADER' | 'ADMIN' | 'SUPERADMIN' | 'EMPRESA';
+
+@Injectable()
+export class AdminService {
+  private readonly logger = new Logger(AdminService.name);
+
+  constructor(
+    private readonly adminRepository: AdminRepository,
+    @Inject(forwardRef(() => UsersService))
+    private readonly usersService: UsersService,
+    private readonly rolesRepository: RolesRepository,
+  ) {}
+
+  async create(
+    createAdminDto: CreateAdminDto,
+    existingQueryRunner?: QueryRunner,
+  ): Promise<Admin> {
+    this.logger.debug(
+      `create(): Intentando crear admin para user_id: ${createAdminDto.user_id}`,
+    );
+
+    const manager = existingQueryRunner
+      ? existingQueryRunner.manager
+      : this.adminRepository.manager;
+    const adminRepo = manager.getRepository(Admin);
+    const userRepo = manager.getRepository(User);
+
+    // Buscar usuario por su ID (PK)
+    const userEntity = await userRepo.findOne({
+      where: { id: createAdminDto.user_id }, // Usar 'id' en lugar de 'auth0_id'
+      withDeleted: false,
+    });
+
+    if (!userEntity) {
+      this.logger.warn(
+        `create(): Usuario con ID "${createAdminDto.user_id}" no encontrado o inactivo. No se puede hacer admin.`,
+      );
+      throw new BadRequestException(
+        `Active user with ID "${createAdminDto.user_id}" not found or is not active. Cannot make admin.`,
+      );
+    }
+
+    const existingAdmin = await adminRepo.findOne({
+      where: { user_id: createAdminDto.user_id },
+    });
+
+    if (existingAdmin) {
+      this.logger.warn(
+        `create(): Usuario con ID "${createAdminDto.user_id}" ya es un admin.`,
+      );
+      throw new ConflictException(
+        `User with ID "${createAdminDto.user_id}" is already an admin.`,
+      );
+    }
+
+    // Corrección: rolesRepository.findByName espera 1 argumento (el nombre)
+    const adminRole = await this.rolesRepository.findByName(
+      'ADMIN' as ValidRoleNames,
+    );
+    if (!adminRole) {
+      this.logger.error(
+        `create(): Rol 'ADMIN' no encontrado en la base de datos.`,
+      );
+      throw new InternalServerErrorException(
+        'Admin role not found in the database. Please ensure it exists and has a UUID.',
+      );
+    }
+
+    let ownQueryRunner: QueryRunner | undefined;
+    if (!existingQueryRunner) {
+      ownQueryRunner =
+        this.adminRepository.manager.connection.createQueryRunner();
+      await ownQueryRunner.connect();
+      await ownQueryRunner.startTransaction();
+    }
+    const currentManager = ownQueryRunner ? ownQueryRunner.manager : manager;
+    const currentAdminRepo = currentManager.getRepository(Admin);
+    const currentUserRepo = currentManager.getRepository(User);
+
+    try {
+      const adminEntity = currentAdminRepo.create({
+        user: userEntity,
+        user_id: userEntity.id, // Asignar el ID (PK) del usuario
+        content_permission: createAdminDto.content_permission,
+        user_permission: createAdminDto.user_permission,
+        moderation_permission: createAdminDto.moderation_permission,
+        finance_permission: createAdminDto.finance_permission,
+        analytics_permission: createAdminDto.analytics_permission,
+        settings_permission: createAdminDto.settings_permission,
+        leader_management_permission:
+          createAdminDto.leader_management_permission,
+        company_management_permission:
+          createAdminDto.company_management_permission,
+      });
+
+      const savedAdmin = await currentAdminRepo.save(adminEntity);
+      this.logger.log(
+        `create(): Entrada de admin creada para user_id: ${createAdminDto.user_id}`,
+      );
+
+      await currentUserRepo.update(
+        { id: userEntity.id },
+        { role_id: adminRole.role_id, role_name: adminRole.name },
+      );
+      this.logger.log(
+        `create(): Rol de usuario ${userEntity.email} actualizado a '${adminRole.name}'.`,
+      );
+
+      const finalAdmin = await currentManager.getRepository(Admin).findOne({
+        where: { admin_id: savedAdmin.admin_id },
+        relations: ['user'],
+      });
+
+      if (!finalAdmin) {
+        throw new InternalServerErrorException(
+          'Failed to retrieve created admin after save.',
+        );
+      }
+
+      if (ownQueryRunner) {
+        await ownQueryRunner.commitTransaction();
+        this.logger.log(
+          `create(): Transacción completada exitosamente para user_id: ${createAdminDto.user_id}`,
+        );
+      }
+
+      return finalAdmin;
+    } catch (error: unknown) {
+      if (ownQueryRunner) {
+        await ownQueryRunner.rollbackTransaction();
+      }
+      this.logger.error(
+        `create(): Error durante la transacción de creación de admin para user_id ${createAdminDto.user_id}:`,
+        error instanceof Error ? error.message : 'Unknown error',
+        error instanceof Error ? error.stack : undefined,
+      );
+      if (
+        error instanceof BadRequestException ||
+        error instanceof ConflictException
+      ) {
+        throw error;
+      }
+      throw new InternalServerErrorException(
+        'Failed to create admin due to an internal error.',
+      );
+    } finally {
+      if (ownQueryRunner) {
+        await ownQueryRunner.release();
+      }
+    }
+  }
+
+  async createOrUpdateAdminEntry(
+    userId: string, // Este userId ahora es el ID (PK) de la tabla User
+    permissions: Partial<Admin>,
+    existingQueryRunner?: QueryRunner,
+  ): Promise<Admin> {
+    this.logger.debug(
+      `createOrUpdateAdminEntry(): Procesando entrada de admin para user_id (PK): ${userId}`,
+    );
+
+    const manager = existingQueryRunner
+      ? existingQueryRunner.manager
+      : this.adminRepository.manager;
+    const adminRepo = manager.getRepository(Admin);
+    const userRepo = manager.getRepository(User);
+
+    // Buscar usuario por su ID (PK)
+    const userEntity = await userRepo.findOne({
+      where: { id: userId }, // Usar 'id' en lugar de 'auth0_id'
+      withDeleted: true,
+    });
+    if (!userEntity) {
+      this.logger.warn(
+        `createOrUpdateAdminEntry(): Usuario con ID "${userId}" no encontrado para operación de admin.`,
+      );
+      throw new NotFoundException(
+        `User with ID "${userId}" not found for admin operation.`,
+      );
+    }
+
+    let adminEntry = await adminRepo.findOne({
+      where: { user_id: userId },
+      relations: ['user'],
+    });
+
+    if (adminEntry) {
+      this.logger.log(
+        `createOrUpdateAdminEntry(): Actualizando permisos para admin existente con user_id: ${userId}`,
+      );
+      Object.assign(adminEntry, permissions);
+      return adminRepo.save(adminEntry);
+    } else {
+      this.logger.log(
+        `createOrUpdateAdminEntry(): Creando nueva entrada de admin para user_id: ${userId}`,
+      );
+      const adminEntity = adminRepo.create({
+        user: userEntity,
+        user_id: userEntity.id, // Asignar el ID (PK) del usuario
+        content_permission: permissions.content_permission,
+        user_permission: permissions.user_permission,
+        moderation_permission: permissions.moderation_permission,
+        finance_permission: permissions.finance_permission,
+        analytics_permission: permissions.analytics_permission,
+        settings_permission: permissions.settings_permission,
+        leader_management_permission: permissions.leader_management_permission,
+        company_management_permission:
+          permissions.company_management_permission,
+      });
+      return adminRepo.save(adminEntity);
+    }
+  }
+
+  async deleteAdminEntry(
+    userId: string, // Este userId ahora es el ID (PK) de la tabla User
+    existingQueryRunner?: QueryRunner,
+  ): Promise<void> {
+    this.logger.debug(
+      `deleteAdminEntry(): Eliminando entrada de admin para user_id (PK): ${userId}`,
+    );
+
+    const manager = existingQueryRunner
+      ? existingQueryRunner.manager
+      : this.adminRepository.manager;
+    const adminRepo = manager.getRepository(Admin);
+
+    const adminEntry = await adminRepo.findOne({
+      where: { user_id: userId },
+    });
+    if (!adminEntry) {
+      this.logger.warn(
+        `deleteAdminEntry(): No se encontró entrada de admin para user_id: ${userId}. No se eliminó nada.`,
+      );
+      return;
+    }
+
+    let ownQueryRunner: QueryRunner | undefined;
+    if (!existingQueryRunner) {
+      ownQueryRunner =
+        this.adminRepository.manager.connection.createQueryRunner();
+      await ownQueryRunner.connect();
+      await ownQueryRunner.startTransaction();
+    }
+    const currentAdminRepo = ownQueryRunner
+      ? ownQueryRunner.manager.getRepository(Admin)
+      : adminRepo;
+
+    try {
+      await currentAdminRepo.delete({ user_id: userId });
+      this.logger.log(
+        `deleteAdminEntry(): Entrada de admin eliminada para user_id: ${userId}.`,
+      );
+
+      if (ownQueryRunner) {
+        await ownQueryRunner.commitTransaction();
+        this.logger.log(
+          `deleteAdminEntry(): Transacción de eliminación de admin completada para user_id: ${userId}.`,
+        );
+      }
+    } catch (error: unknown) {
+      if (ownQueryRunner) {
+        await ownQueryRunner.rollbackTransaction();
+      }
+      this.logger.error(
+        `deleteAdminEntry(): Error durante la transacción de eliminación de admin para user_id ${userId}:`,
+        error instanceof Error ? error.message : 'Unknown error',
+      );
+      throw new InternalServerErrorException('Failed to remove admin entry.');
+    } finally {
+      if (ownQueryRunner) {
+        await ownQueryRunner.release();
+      }
+    }
+  }
+
+  async findAll(): Promise<Admin[]> {
+    this.logger.debug('findAll(): Buscando todos los administradores.');
+    return this.adminRepository.findAll();
+  }
+
+  async findOne(admin_id: string): Promise<Admin> {
+    this.logger.debug(`findOne(): Buscando administrador con ID: ${admin_id}`);
+    const admin = await this.adminRepository.findOneByAdminId(admin_id);
+    if (!admin) {
+      this.logger.warn(
+        `findOne(): Administrador con ID "${admin_id}" no encontrado.`,
+      );
+      throw new NotFoundException(`Admin with ID "${admin_id}" not found.`);
+    }
+    return admin;
+  }
+
+  async findByUserIdInternal(user_id: string): Promise<Admin | null> {
+    this.logger.debug(
+      `findByUserIdInternal(): Buscando administrador por user_id (PK): ${user_id}`,
+    );
+    return this.adminRepository.findByUserId(user_id);
+  }
+
+  async update(
+    admin_id: string,
+    updateAdminDto: UpdateAdminDto,
+  ): Promise<Admin> {
+    this.logger.debug(
+      `update(): Actualizando administrador con ID: ${admin_id}`,
+    );
+    const admin = await this.adminRepository.findOneByAdminId(admin_id);
+    if (!admin) {
+      this.logger.warn(
+        `update(): Administrador con ID "${admin_id}" no encontrado.`,
+      );
+      throw new NotFoundException(`Admin with ID "${admin_id}" not found.`);
+    }
+
+    if (updateAdminDto.user_id && updateAdminDto.user_id !== admin.user_id) {
+      this.logger.warn(
+        `update(): Intentando cambiar user_id de admin ${admin_id}. Operación no permitida.`,
+      );
+      throw new BadRequestException(
+        'Cannot change the user of an existing admin record. Please delete and create a new one.',
+      );
+    }
+
+    const { user_id, ...permissionsToUpdate } = updateAdminDto;
+    Object.assign(admin, permissionsToUpdate);
+
+    const updatedAdmin = await this.adminRepository.save(admin);
+    this.logger.log(
+      `update(): Administrador ${admin_id} actualizado exitosamente.`,
+    );
+    return this.adminRepository.findOneByAdminId(
+      updatedAdmin.admin_id,
+    ) as Promise<Admin>;
+  }
+
+  async remove(admin_id: string): Promise<void> {
+    this.logger.debug(
+      `remove(): Intentando eliminar administrador con ID: ${admin_id}`,
+    );
+
+    const admin = await this.adminRepository.findOneByAdminId(admin_id);
+    if (!admin) {
+      this.logger.warn(
+        `remove(): Administrador con ID "${admin_id}" no encontrado.`,
+      );
+      throw new NotFoundException(`Admin with ID "${admin_id}" not found.`);
+    }
+
+    const defaultRole = await this.rolesRepository.findByName(
+      'USER' as ValidRoleNames,
+    );
+
+    if (!defaultRole) {
+      this.logger.error(
+        `remove(): Rol 'USER' por defecto no encontrado. Incapaz de resetear rol de usuario.`,
+      );
+      throw new InternalServerErrorException(
+        'Default role "USER" not found in the database. Cannot reset user role.',
+      );
+    }
+
+    const queryRunner =
+      this.adminRepository.manager.connection.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    try {
+      const adminRepo = queryRunner.manager.getRepository(Admin);
+      const userRepo = queryRunner.manager.getRepository(User);
+
+      const deleteResult = await adminRepo.delete({ admin_id });
+      if (deleteResult.affected === 0) {
+        this.logger.warn(
+          `remove(): No se pudo eliminar la entrada de admin con ID "${admin_id}".`,
+        );
+        throw new NotFoundException(`Admin with ID "${admin_id}" not found.`);
+      }
+      this.logger.log(`remove(): Entrada de admin ${admin_id} eliminada.`);
+
+      // Buscar el usuario por su ID (PK)
+      if (admin.user_id) {
+        const userToUpdate = await userRepo.findOne({
+          where: { id: admin.user_id }, // Usar 'id' en lugar de 'auth0_id'
+        });
+        if (userToUpdate) {
+          await userRepo.update(
+            { id: userToUpdate.id },
+            { role_id: defaultRole.role_id, role_name: defaultRole.name },
+          );
+          this.logger.log(
+            `remove(): Rol del usuario ${userToUpdate.email} reseteado a '${defaultRole.name}' mediante actualización directa.`,
+          );
+        } else {
+          this.logger.warn(
+            `remove(): Usuario asociado (ID: ${admin.user_id}) al admin ${admin_id} no encontrado para resetear rol.`,
+          );
+        }
+      } else {
+        this.logger.warn(
+          `remove(): Admin ${admin_id} no tiene user_id (PK) asociado. No se pudo resetear el rol del usuario.`,
+        );
+      }
+
+      await queryRunner.commitTransaction();
+      this.logger.log(
+        `remove(): Transacción de eliminación de admin completada exitosamente para ID: ${admin_id}`,
+      );
+    } catch (error: unknown) {
+      await queryRunner.rollbackTransaction();
+      this.logger.error(
+        `remove(): Error durante la transacción de eliminación de admin para ID ${admin_id}:`,
+        error instanceof Error ? error.message : 'Unknown error',
+        error instanceof Error ? error.stack : undefined,
+      );
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      throw new InternalServerErrorException(
+        'Failed to remove admin due to an internal error.',
+      );
+    } finally {
+      if (queryRunner) {
+        await queryRunner.release();
+      }
+    }
+  }
+
+  async removeAdminPermissionsByUserIdInternal(
+    user_id: string, // Este userId ahora es el ID (PK) de la tabla User
+    queryRunner: QueryRunner,
+  ): Promise<DeleteResult> {
+    this.logger.debug(
+      `removeAdminPermissionsByUserIdInternal(): Eliminando permisos de admin para user_id (PK): ${user_id}`,
+    );
+    const transactionalAdminRepository =
+      queryRunner.manager.getRepository(Admin);
+
+    const deleteResult = await transactionalAdminRepository.delete({
+      user_id: user_id,
+    });
+
+    return deleteResult;
+  }
+}

--- a/beland-backend/src/admins/dto/admin.dto.ts
+++ b/beland-backend/src/admins/dto/admin.dto.ts
@@ -1,0 +1,46 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsUUID, IsBoolean, IsString } from 'class-validator';
+
+export class AdminDto {
+  @IsUUID()
+  @ApiProperty({ description: 'ID único del administrador.' })
+  admin_id: string;
+
+  @IsUUID() // user_id ahora es un UUID
+  @ApiProperty({
+    description: 'ID (PK) del usuario asociado a este administrador.',
+  }) // Descripción actualizada
+  user_id: string;
+
+  @IsBoolean()
+  @ApiProperty({ description: 'Permiso para gestionar contenido.' })
+  content_permission: boolean;
+
+  @IsBoolean()
+  @ApiProperty({ description: 'Permiso para gestionar usuarios.' })
+  user_permission: boolean;
+
+  @IsBoolean()
+  @ApiProperty({ description: 'Permiso para moderar.' })
+  moderation_permission: boolean;
+
+  @IsBoolean()
+  @ApiProperty({ description: 'Permiso para gestionar finanzas.' })
+  finance_permission: boolean;
+
+  @IsBoolean()
+  @ApiProperty({ description: 'Permiso para ver analíticas.' })
+  analytics_permission: boolean;
+
+  @IsBoolean()
+  @ApiProperty({ description: 'Permiso para gestionar configuraciones.' })
+  settings_permission: boolean;
+
+  @IsBoolean()
+  @ApiProperty({ description: 'Permiso para gestionar líderes.' })
+  leader_management_permission: boolean;
+
+  @IsBoolean()
+  @ApiProperty({ description: 'Permiso para gestionar empresas.' })
+  company_management_permission: boolean;
+}

--- a/beland-backend/src/admins/dto/create-admin.dto.ts
+++ b/beland-backend/src/admins/dto/create-admin.dto.ts
@@ -1,0 +1,90 @@
+import {
+  IsBoolean,
+  IsOptional,
+  IsNotEmpty,
+  IsString,
+  IsUUID,
+} from 'class-validator'; // Importar IsUUID
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateAdminDto {
+  @IsUUID() // Asegura que user_id sea un UUID válido
+  @IsNotEmpty()
+  @ApiProperty({
+    description:
+      'ID (PK) del usuario al que se le otorgan permisos de administrador.', // Descripción actualizada
+  })
+  user_id: string; // Ahora es el ID (UUID) del usuario
+
+  @IsOptional()
+  @IsBoolean()
+  @ApiProperty({
+    description: 'Permiso para gestionar contenido.',
+    default: true,
+    required: false,
+  })
+  content_permission?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  @ApiProperty({
+    description: 'Permiso para gestionar usuarios.',
+    default: true,
+    required: false,
+  })
+  user_permission?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  @ApiProperty({
+    description: 'Permiso para moderar.',
+    default: true,
+    required: false,
+  })
+  moderation_permission?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  @ApiProperty({
+    description: 'Permiso para gestionar finanzas.',
+    default: true,
+    required: false,
+  })
+  finance_permission?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  @ApiProperty({
+    description: 'Permiso para ver analíticas.',
+    default: true,
+    required: false,
+  })
+  analytics_permission?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  @ApiProperty({
+    description: 'Permiso para gestionar configuraciones.',
+    default: true,
+    required: false,
+  })
+  settings_permission?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  @ApiProperty({
+    description: 'Permiso para gestionar líderes.',
+    default: true,
+    required: false,
+  })
+  leader_management_permission?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  @ApiProperty({
+    description: 'Permiso para gestionar empresas.',
+    default: true,
+    required: false,
+  })
+  company_management_permission?: boolean;
+}

--- a/beland-backend/src/admins/dto/update-admin.dto.ts
+++ b/beland-backend/src/admins/dto/update-admin.dto.ts
@@ -1,0 +1,69 @@
+import { IsBoolean, IsOptional, IsUUID } from 'class-validator'; // Importar IsUUID
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UpdateAdminDto {
+  @IsUUID() // user_id ahora es un UUID
+  @IsOptional()
+  user_id?: string; // Aunque no se permite cambiar, se mantiene para consistencia del DTO
+
+  @IsOptional()
+  @IsBoolean()
+  @ApiProperty({
+    description: 'Permiso para gestionar contenido.',
+    required: false,
+  })
+  content_permission?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  @ApiProperty({
+    description: 'Permiso para gestionar usuarios.',
+    required: false,
+  })
+  user_permission?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  @ApiProperty({ description: 'Permiso para moderar.', required: false })
+  moderation_permission?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  @ApiProperty({
+    description: 'Permiso para gestionar finanzas.',
+    required: false,
+  })
+  finance_permission?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  @ApiProperty({
+    description: 'Permiso para ver analíticas.',
+    required: false,
+  })
+  analytics_permission?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  @ApiProperty({
+    description: 'Permiso para gestionar configuraciones.',
+    required: false,
+  })
+  settings_permission?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  @ApiProperty({
+    description: 'Permiso para gestionar líderes.',
+    required: false,
+  })
+  leader_management_permission?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  @ApiProperty({
+    description: 'Permiso para gestionar empresas.',
+    required: false,
+  })
+  company_management_permission?: boolean;
+}

--- a/beland-backend/src/admins/entities/admin.entity.ts
+++ b/beland-backend/src/admins/entities/admin.entity.ts
@@ -1,0 +1,72 @@
+// src/admins/entities/admin.entity.ts
+import { User } from '../../users/entities/users.entity';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  OneToOne,
+  JoinColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity('admins')
+export class Admin {
+  @PrimaryGeneratedColumn('uuid')
+  admin_id: string;
+
+  // Cambiado para referenciar el 'id' (PK) de la tabla User
+  @Column({ type: 'uuid', unique: true, name: 'user_id' })
+  user_id: string; // Este es ahora el 'id' (UUID) del User
+
+  @OneToOne(() => User, (user) => user.admin, { onDelete: 'CASCADE' })
+  // La columna referenciada ahora es 'id' de la tabla User
+  @JoinColumn({ name: 'user_id', referencedColumnName: 'id' })
+  user: User;
+
+  @Column({
+    type: 'timestamptz',
+    name: 'assigned_at',
+    nullable: true,
+    default: () => 'NOW()',
+  })
+  assigned_at: Date;
+
+  @Column({ type: 'boolean', default: true, name: 'content_permission' })
+  content_permission: boolean;
+
+  @Column({ type: 'boolean', default: true, name: 'user_permission' })
+  user_permission: boolean;
+
+  @Column({ type: 'boolean', default: true, name: 'moderation_permission' })
+  moderation_permission: boolean;
+
+  @Column({ type: 'boolean', default: true, name: 'finance_permission' })
+  finance_permission: boolean;
+
+  @Column({ type: 'boolean', default: true, name: 'analytics_permission' })
+  analytics_permission: boolean;
+
+  @Column({ type: 'boolean', default: true, name: 'settings_permission' })
+  settings_permission: boolean;
+
+  @Column({
+    type: 'boolean',
+    default: true,
+    name: 'leader_management_permission',
+  })
+  leader_management_permission: boolean;
+
+  @Column({
+    type: 'boolean',
+    default: true,
+    name: 'company_management_permission',
+  })
+  company_management_permission: boolean;
+
+  @CreateDateColumn({ type: 'timestamptz', name: 'created_at' })
+  created_at: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz', name: 'updated_at' })
+  updated_at: Date;
+}

--- a/beland-backend/src/app.module.ts
+++ b/beland-backend/src/app.module.ts
@@ -29,6 +29,7 @@ import { DataSourceOptions } from 'typeorm';
 import typeormConfig from './config/typeorm';
 import { RequestLoggerMiddleware } from './middlleware/request-logger.middleware';
 import { DatabaseInitModule } from './database/init/database-init.module';
+import { AdminsModule } from './admins/admins.module';
 
 @Module({
   imports: [
@@ -79,6 +80,7 @@ import { DatabaseInitModule } from './database/init/database-init.module';
     CouponsModule,
     AuthModule,
     CommonModule,
+    AdminsModule,
   ],
   controllers: [],
   providers: [

--- a/beland-backend/src/auth/decorators/permissions.decorator.ts
+++ b/beland-backend/src/auth/decorators/permissions.decorator.ts
@@ -1,0 +1,19 @@
+import { SetMetadata } from '@nestjs/common';
+
+// Define los nombres de los permisos que podemos verificar en la aplicación Beland
+export type AdminPermission =
+  | 'content_permission' // Permiso para gestionar contenido (ej. artículos, productos, publicaciones)
+  | 'user_permission' // Permiso para gestionar usuarios (crear, actualizar, bloquear, desactivar, asignar roles)
+  | 'moderation_permission' // Permiso para moderar (ej. comentarios, reportes, contenido inapropiado)
+  | 'finance_permission' // Permiso para gestionar transacciones, saldos, pagos, etc.
+  | 'analytics_permission' // Permiso para acceder a dashboards y reportes de datos de la aplicación.
+  | 'settings_permission' // Permiso para cambiar configuraciones globales de la aplicación.
+  | 'leader_management_permission' // Permiso para gestionar específicamente a los usuarios con rol 'LEADER'.
+  | 'company_management_permission'; // Permiso para gestionar específicamente a los usuarios con rol 'EMPRESA'.
+
+// Clave para almacenar los permisos requeridos en los metadatos de la ruta
+export const PERMISSIONS_KEY = 'permissions';
+
+// Decorador para especificar los permisos granulares requeridos en una ruta
+export const RequiredPermissions = (...permissions: AdminPermission[]) =>
+  SetMetadata(PERMISSIONS_KEY, permissions);

--- a/beland-backend/src/auth/guards/permissions.guard.ts
+++ b/beland-backend/src/auth/guards/permissions.guard.ts
@@ -1,0 +1,96 @@
+// src/auth/guards/permissions.guard.ts
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+  Logger,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import {
+  PERMISSIONS_KEY,
+  AdminPermission,
+} from '../decorators/permissions.decorator'; // Importar la clave y el tipo de permiso
+import { User } from 'src/users/entities/users.entity'; // Importar la entidad User
+import { AdminService } from 'src/admins/admins.service'; // Importar AdminService
+import { Admin } from 'src/admins/entities/admin.entity'; // Importar la entidad Admin
+
+@Injectable()
+export class PermissionsGuard implements CanActivate {
+  private readonly logger = new Logger(PermissionsGuard.name);
+
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly adminService: AdminService, // Inyectar AdminService
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    // Obtener los permisos requeridos de los metadatos de la ruta
+    const requiredPermissions = this.reflector.getAllAndOverride<
+      AdminPermission[]
+    >(PERMISSIONS_KEY, [context.getHandler(), context.getClass()]);
+
+    // Si no hay permisos requeridos, permitir el acceso
+    if (!requiredPermissions) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest();
+    // Asumimos que el JwtAuthGuard ya ha adjuntado el usuario completo a la request.
+    const user: User = request.user;
+
+    this.logger.debug(`Permisos requeridos: ${requiredPermissions.join(', ')}`);
+    this.logger.debug(`Usuario autenticado (ID): ${user ? user.id : 'N/A'}`);
+
+    // Si no hay usuario, denegar acceso
+    if (!user) {
+      this.logger.warn('Acceso denegado: Usuario no autenticado.');
+      throw new ForbiddenException(
+        'No tienes los permisos necesarios para esta solicitud.',
+      );
+    }
+
+    // Si el usuario no es ADMIN o SUPERADMIN, no tiene permisos administrativos granulares
+    if (user.role_name !== 'ADMIN' && user.role_name !== 'SUPERADMIN') {
+      this.logger.warn(
+        `Acceso denegado: Usuario "${user.email}" no es Admin o Superadmin.`,
+      );
+      throw new ForbiddenException(
+        'No tienes los permisos necesarios para esta solicitud.',
+      );
+    }
+
+    // Obtener la entrada de administrador para el usuario
+    // Usamos findByUserIdInternal que busca por el ID (PK) del usuario
+    const adminEntry: Admin | null =
+      await this.adminService.findByUserIdInternal(user.id);
+
+    if (!adminEntry) {
+      this.logger.warn(
+        `Acceso denegado: No se encontró entrada de admin para el usuario ID "${user.id}".`,
+      );
+      throw new ForbiddenException(
+        'No tienes los permisos necesarios para esta solicitud.',
+      );
+    }
+
+    // Verificar si el administrador tiene TODOS los permisos requeridos
+    const hasAllRequiredPermissions = requiredPermissions.every(
+      (permission) => {
+        // Asegurarse de que la propiedad existe y es verdadera
+        return adminEntry[permission] === true;
+      },
+    );
+
+    if (!hasAllRequiredPermissions) {
+      this.logger.warn(
+        `Acceso denegado: Admin "${user.id}" no tiene todos los permisos requeridos.`,
+      );
+      throw new ForbiddenException(
+        'No tienes los permisos necesarios para esta solicitud.',
+      );
+    }
+
+    return true;
+  }
+}

--- a/beland-backend/src/auth/guards/roles.guard.ts
+++ b/beland-backend/src/auth/guards/roles.guard.ts
@@ -1,0 +1,61 @@
+// src/auth/guards/roles.guard.ts
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+  Logger,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ROLES_KEY } from '../decorators/roles.decorator'; // Importar la clave del decorador
+import { User } from 'src/users/entities/users.entity'; // Importar la entidad User
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  private readonly logger = new Logger(RolesGuard.name);
+
+  constructor(private readonly reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    // Obtener los roles requeridos de los metadatos de la ruta
+    const requiredRoles = this.reflector.getAllAndOverride<string[]>(
+      ROLES_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    // Si no hay roles requeridos, permitir el acceso
+    if (!requiredRoles) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest();
+    // Asumimos que el JwtAuthGuard ya ha adjuntado el usuario completo (incluyendo role_name) a la request.
+    // La propiedad 'user' en la request es el resultado de la validación del Passport Strategy.
+    const user: User = request.user;
+
+    this.logger.debug(`Roles requeridos: ${requiredRoles.join(', ')}`);
+    this.logger.debug(`Rol del usuario: ${user ? user.role_name : 'N/A'}`);
+
+    // Si no hay usuario o el usuario no tiene rol, denegar acceso
+    if (!user || !user.role_name) {
+      this.logger.warn('Acceso denegado: Usuario no autenticado o sin rol.');
+      throw new ForbiddenException(
+        'No tienes los permisos necesarios para esta solicitud.',
+      );
+    }
+
+    // Verificar si el rol del usuario está incluido en los roles requeridos
+    const hasRequiredRole = requiredRoles.includes(user.role_name);
+
+    if (!hasRequiredRole) {
+      this.logger.warn(
+        `Acceso denegado: Rol del usuario "${user.role_name}" no autorizado para esta ruta.`,
+      );
+      throw new ForbiddenException(
+        'No tienes los permisos necesarios para esta solicitud.',
+      );
+    }
+
+    return true;
+  }
+}

--- a/beland-backend/src/coupons/entities/coupon.entity.ts
+++ b/beland-backend/src/coupons/entities/coupon.entity.ts
@@ -1,4 +1,4 @@
-// coupon.entity.ts
+// src/coupons/entities/coupon.entity.ts
 import {
   Entity,
   PrimaryGeneratedColumn,
@@ -34,6 +34,6 @@ export class Coupon {
   @CreateDateColumn({ type: 'timestamptz' })
   created_at: Date;
 
-  @ManyToOne(() => User, (user) => user.redeemed_coupons)
+  @ManyToOne(() => User, (user) => user.coupons)
   redeemed_by_user: User;
 }

--- a/beland-backend/src/database/database.sql
+++ b/beland-backend/src/database/database.sql
@@ -1,0 +1,325 @@
+-- WARNING: This schema is for context only and is not meant to be run.
+-- Table order and constraints may not be valid for execution.
+
+CREATE TABLE public.actions (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL,
+  description text,
+  transaction_hash text,
+  block_number integer,
+  timestamp timestamp with time zone NOT NULL DEFAULT now(),
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT actions_pkey PRIMARY KEY (id),
+  CONSTRAINT FK_314aaf9c37b61b0a1267c1f4b59 FOREIGN KEY (user_id) REFERENCES public.users(id)
+);
+CREATE TABLE public.admins (
+  admin_id uuid NOT NULL DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL UNIQUE,
+  assigned_at timestamp with time zone DEFAULT now(),
+  content_permission boolean NOT NULL DEFAULT true,
+  user_permission boolean NOT NULL DEFAULT true,
+  moderation_permission boolean NOT NULL DEFAULT true,
+  finance_permission boolean NOT NULL DEFAULT true,
+  analytics_permission boolean NOT NULL DEFAULT true,
+  settings_permission boolean NOT NULL DEFAULT true,
+  leader_management_permission boolean NOT NULL DEFAULT true,
+  company_management_permission boolean NOT NULL DEFAULT true,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT admins_pkey PRIMARY KEY (admin_id),
+  CONSTRAINT admins_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id)
+);
+CREATE TABLE public.bank_account_types (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  code character varying NOT NULL UNIQUE,
+  name character varying NOT NULL,
+  description text,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT bank_account_types_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.bank_accounts (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  owner_name text NOT NULL,
+  bank_code character varying NOT NULL,
+  account_type_id uuid NOT NULL,
+  cbu character varying NOT NULL,
+  alias text,
+  user_id uuid NOT NULL,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT bank_accounts_pkey PRIMARY KEY (id),
+  CONSTRAINT FK_799340cb97c2a26cd1814ac90fc FOREIGN KEY (account_type_id) REFERENCES public.bank_account_types(id),
+  CONSTRAINT FK_29146c4a8026c77c712e01d922b FOREIGN KEY (user_id) REFERENCES public.users(id)
+);
+CREATE TABLE public.charities (
+  id uuid NOT NULL DEFAULT uuid_generate_v4(),
+  name character varying NOT NULL,
+  display_name character varying,
+  registration_number character varying NOT NULL UNIQUE,
+  description text,
+  website character varying,
+  email character varying NOT NULL,
+  phone character varying,
+  address character varying,
+  logo_url character varying,
+  wallet_id uuid UNIQUE,
+  user_id uuid NOT NULL UNIQUE,
+  is_active boolean NOT NULL DEFAULT true,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT charities_pkey PRIMARY KEY (id),
+  CONSTRAINT FK_f4d22dadb80086b25c0e12e9b3c FOREIGN KEY (user_id) REFERENCES public.users(id),
+  CONSTRAINT FK_67791ce53cb9c75a58496c2a750 FOREIGN KEY (wallet_id) REFERENCES public.wallets(id)
+);
+CREATE TABLE public.coupons (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  code text NOT NULL UNIQUE,
+  type text NOT NULL,
+  value numeric NOT NULL,
+  is_redeemed boolean NOT NULL DEFAULT false,
+  redeemed_by_user_id uuid,
+  redeemed_at timestamp with time zone,
+  expires_at timestamp with time zone,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT coupons_pkey PRIMARY KEY (id),
+  CONSTRAINT FK_2326117d6ad81572d73c73fcb17 FOREIGN KEY (redeemed_by_user_id) REFERENCES public.users(id)
+);
+CREATE TABLE public.group_members (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  group_id uuid NOT NULL,
+  user_id uuid NOT NULL,
+  role text NOT NULL DEFAULT 'MEMBER'::text,
+  joined_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT group_members_pkey PRIMARY KEY (id),
+  CONSTRAINT FK_2c840df5db52dc6b4a1b0b69c6e FOREIGN KEY (group_id) REFERENCES public.groups(id),
+  CONSTRAINT FK_20a555b299f75843aa53ff8b0ee FOREIGN KEY (user_id) REFERENCES public.users(id)
+);
+CREATE TABLE public.groups (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  name text NOT NULL,
+  location text,
+  location_url text,
+  status text NOT NULL DEFAULT 'ACTIVE'::text,
+  loader_id uuid NOT NULL,
+  date_time timestamp with time zone,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT groups_pkey PRIMARY KEY (id),
+  CONSTRAINT FK_72ad1e93ec761661298426680dc FOREIGN KEY (loader_id) REFERENCES public.users(id)
+);
+CREATE TABLE public.inventory_items (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  product_id uuid NOT NULL,
+  quantity_available integer NOT NULL DEFAULT 0,
+  offer_label text,
+  promotion_expires_at timestamp with time zone,
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT inventory_items_pkey PRIMARY KEY (id),
+  CONSTRAINT FK_8e17955a29e8b63bb8cec3d32c5 FOREIGN KEY (product_id) REFERENCES public.products(id)
+);
+CREATE TABLE public.merchants (
+  id uuid NOT NULL DEFAULT uuid_generate_v4(),
+  business_name character varying NOT NULL,
+  legal_name character varying,
+  ruc character varying,
+  category character varying,
+  description text,
+  phone character varying,
+  email character varying,
+  address character varying,
+  city character varying,
+  province character varying,
+  country character varying,
+  latitude numeric,
+  longitude numeric,
+  website character varying,
+  is_active boolean NOT NULL DEFAULT true,
+  user_id uuid NOT NULL UNIQUE,
+  created_at timestamp without time zone NOT NULL DEFAULT now(),
+  updated_at timestamp without time zone NOT NULL DEFAULT now(),
+  CONSTRAINT merchants_pkey PRIMARY KEY (id),
+  CONSTRAINT FK_698f612a3134c503f711479a4e5 FOREIGN KEY (user_id) REFERENCES public.users(id)
+);
+CREATE TABLE public.order_items (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  order_id uuid NOT NULL,
+  product_id uuid NOT NULL,
+  quantity integer NOT NULL,
+  unit_price numeric NOT NULL,
+  total_price numeric NOT NULL,
+  consumed_by_user_id uuid NOT NULL,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT order_items_pkey PRIMARY KEY (id),
+  CONSTRAINT FK_9263386c35b6b242540f9493b00 FOREIGN KEY (product_id) REFERENCES public.products(id),
+  CONSTRAINT FK_6416a99947f9349d4268bfd33fd FOREIGN KEY (consumed_by_user_id) REFERENCES public.users(id),
+  CONSTRAINT FK_145532db85752b29c57d2b7b1f1 FOREIGN KEY (order_id) REFERENCES public.orders(id)
+);
+CREATE TABLE public.orders (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  group_id uuid NOT NULL,
+  leader_id uuid NOT NULL,
+  status text NOT NULL DEFAULT 'PENDING_PAYMENT'::text,
+  total_amount numeric NOT NULL DEFAULT 0,
+  group_ip uuid,
+  leader_ip uuid,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  paid_at timestamp with time zone,
+  CONSTRAINT orders_pkey PRIMARY KEY (id),
+  CONSTRAINT FK_f6828c894e0e6c5733452cfc5f2 FOREIGN KEY (group_ip) REFERENCES public.groups(id),
+  CONSTRAINT FK_6a4e2e91f771d5c19e0ae10252b FOREIGN KEY (leader_ip) REFERENCES public.users(id)
+);
+CREATE TABLE public.payment_methods (
+  id uuid NOT NULL DEFAULT uuid_generate_v4(),
+  user_id uuid NOT NULL,
+  token text NOT NULL,
+  description text,
+  brand text NOT NULL,
+  last4 text NOT NULL,
+  is_default boolean NOT NULL DEFAULT false,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT payment_methods_pkey PRIMARY KEY (id),
+  CONSTRAINT FK_d7d7fb15569674aaadcfbc0428c FOREIGN KEY (user_id) REFERENCES public.users(id)
+);
+CREATE TABLE public.payments (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  order_id uuid NOT NULL,
+  user_id uuid NOT NULL,
+  amount_paid numeric NOT NULL,
+  payment_type text NOT NULL,
+  transaction_hash text,
+  payment_date timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT payments_pkey PRIMARY KEY (id),
+  CONSTRAINT FK_427785468fb7d2733f59e7d7d39 FOREIGN KEY (user_id) REFERENCES public.users(id),
+  CONSTRAINT FK_b2f7b823a21562eeca20e72b006 FOREIGN KEY (order_id) REFERENCES public.orders(id)
+);
+CREATE TABLE public.prize_redemptions (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  status text NOT NULL,
+  userId uuid,
+  prizeId uuid,
+  redemption_date timestamp with time zone NOT NULL DEFAULT now(),
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT prize_redemptions_pkey PRIMARY KEY (id),
+  CONSTRAINT FK_7704b2cd9e65abdea8def84e12a FOREIGN KEY (prizeId) REFERENCES public.prizes(id),
+  CONSTRAINT FK_7c40bfd9517df0aa875026703b5 FOREIGN KEY (userId) REFERENCES public.users(id)
+);
+CREATE TABLE public.prizes (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  name text NOT NULL,
+  description text,
+  cost numeric NOT NULL,
+  image_url text,
+  stock integer NOT NULL DEFAULT 0,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT prizes_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.products (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  name text NOT NULL,
+  description text,
+  price numeric NOT NULL,
+  image_url text,
+  category text,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  deleted_at timestamp with time zone,
+  CONSTRAINT products_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.recycle_prices (
+  id uuid NOT NULL DEFAULT uuid_generate_v4(),
+  material_type character varying NOT NULL,
+  becoin_value numeric NOT NULL DEFAULT '0'::numeric,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT recycle_prices_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.recycled_items (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  product_id uuid NOT NULL,
+  scanned_by_user_id uuid NOT NULL,
+  is_redeemed boolean NOT NULL DEFAULT false,
+  redeemed_at timestamp with time zone,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT recycled_items_pkey PRIMARY KEY (id),
+  CONSTRAINT FK_7f2b1b844405ac9bba63334035b FOREIGN KEY (scanned_by_user_id) REFERENCES public.users(id),
+  CONSTRAINT FK_69d4cabd205e8c98c6f42d2edb9 FOREIGN KEY (product_id) REFERENCES public.products(id)
+);
+CREATE TABLE public.roles (
+  role_id uuid NOT NULL DEFAULT gen_random_uuid(),
+  name text NOT NULL UNIQUE,
+  description text,
+  is_active boolean NOT NULL DEFAULT true,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT roles_pkey PRIMARY KEY (role_id)
+);
+CREATE TABLE public.transaction_states (
+  id uuid NOT NULL DEFAULT uuid_generate_v4(),
+  code character varying NOT NULL UNIQUE,
+  name character varying NOT NULL,
+  description text,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT transaction_states_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.transaction_types (
+  id uuid NOT NULL DEFAULT uuid_generate_v4(),
+  code character varying NOT NULL UNIQUE,
+  name character varying NOT NULL,
+  description text,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT transaction_types_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.transactions (
+  id uuid NOT NULL DEFAULT uuid_generate_v4(),
+  wallet_id uuid NOT NULL,
+  type_id uuid NOT NULL,
+  status_id uuid NOT NULL,
+  amount numeric NOT NULL,
+  post_balance numeric NOT NULL,
+  related_wallet_id uuid,
+  reference text,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT transactions_pkey PRIMARY KEY (id),
+  CONSTRAINT FK_0b171330be0cb621f8d73b87a9e FOREIGN KEY (wallet_id) REFERENCES public.wallets(id),
+  CONSTRAINT FK_bf1cb034a93b703e528b926a75d FOREIGN KEY (type_id) REFERENCES public.transaction_types(id),
+  CONSTRAINT FK_819b9b741319d533ea9e5617eb0 FOREIGN KEY (status_id) REFERENCES public.transaction_states(id)
+);
+CREATE TABLE public.users (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  oauth_provider text,
+  email text NOT NULL UNIQUE,
+  username text,
+  full_name text,
+  profile_picture_url text,
+  current_balance numeric NOT NULL DEFAULT 0,
+  role_name text NOT NULL DEFAULT 'USER'::text,
+  role_id uuid,
+  auth0_id text,
+  address text,
+  phone numeric,
+  country text,
+  city text,
+  isblocked boolean NOT NULL DEFAULT false,
+  deleted_at timestamp with time zone,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  password text,
+  CONSTRAINT users_pkey PRIMARY KEY (id),
+  CONSTRAINT FK_a2cecd1a3531c0b041e29ba46e1 FOREIGN KEY (role_id) REFERENCES public.roles(role_id)
+);
+CREATE TABLE public.wallets (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  address text,
+  alias text,
+  qr text,
+  becoin_balance numeric NOT NULL DEFAULT 0,
+  locked_balance numeric NOT NULL DEFAULT 0,
+  private_key_encrypted text,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  user_id uuid NOT NULL,
+  bank_account_id uuid UNIQUE,
+  CONSTRAINT wallets_pkey PRIMARY KEY (id),
+  CONSTRAINT FK_92558c08091598f7a4439586cda FOREIGN KEY (user_id) REFERENCES public.users(id),
+  CONSTRAINT FK_94dae15c154c2b28813e04750c7 FOREIGN KEY (bank_account_id) REFERENCES public.bank_accounts(id)
+);


### PR DESCRIPTION
Introduces a full admins module including controller, service, repository, DTOs, and entity for managing admin users and their granular permissions. Adds permissions and roles guards, as well as decorators for role and permission-based access control. Updates app.module to register the new module, and provides a database schema for context. Also fixes a relation in the coupon entity.