### PR TITLE
[FIX] Switch to FlexibleAuthGuard and update CORS origins

### DIFF
--- a/beland-backend/src/groups/groups.controller.ts
+++ b/beland-backend/src/groups/groups.controller.ts
@@ -46,10 +46,11 @@ import { GroupMemberDto } from 'src/group-members/dto/group-member.dto';
 import { UpdateGroupMemberDto } from 'src/group-members/dto/update-group-member.dto';
 import { UsersService } from 'src/users/users.service'; // <-- ADDED: Import UsersService
 import { CreateGroupMemberDto } from 'src/group-members/dto/create-group-member.dto'; // <-- ADDED: Import CreateGroupMemberDto
+import { FlexibleAuthGuard } from 'src/auth/guards/flexible-auth.guard';
 
 @ApiTags('groups') // Tag for Swagger documentation
 @Controller('groups')
-@UseGuards(JwtAuthGuard, RolesGuard, PermissionsGuard) // Apply guards to all routes in this controller
+@UseGuards(FlexibleAuthGuard, RolesGuard, PermissionsGuard) // Apply guards to all routes in this controller
 export class GroupsController {
   private readonly logger = new Logger(GroupsController.name); // Initialize logger
 

--- a/beland-backend/src/main.ts
+++ b/beland-backend/src/main.ts
@@ -43,6 +43,7 @@ async function bootstrap() {
       'http://localhost:8081',
       'https://auth.expo.io/@beland/Beland',
       'belandnative://redirect',
+      'https://eoy0nfm-beland-8081.exp.direct',
     ],
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
     credentials: true,


### PR DESCRIPTION
Replaces JwtAuthGuard with FlexibleAuthGuard in GroupsController to allow more flexible authentication. Adds 'https://eoy0nfm-beland-8081.exp.direct' to allowed CORS origins in main.ts for improved development or deployment compatibility.