### PR TITLE
[FEAT] Add testimonies module with CRUD and entity relations

### DIFF
--- a/beland-backend/src/app.module.ts
+++ b/beland-backend/src/app.module.ts
@@ -56,6 +56,7 @@ import { UserWithdrawModule } from './user-withdraw/user-withdraw.module';
 import { AmountToPaymentModule } from './amount-to-payment/amount-to-payment.module';
 import { PresetAmountModule } from './preset-amount/preset-amount.module';
 //import { NotificationsSocketModule } from './notification-socket/notification-socket.module'; 
+import { TestimoniesModule } from './testimonies/testimonies.module';
 
 @Module({
   imports: [
@@ -155,6 +156,7 @@ import { PresetAmountModule } from './preset-amount/preset-amount.module';
     UserWithdrawModule,
     AmountToPaymentModule,
     PresetAmountModule,
+    TestimoniesModule,
     //NotificationsSocketModule,
   ],
   controllers: [],

--- a/beland-backend/src/testimonies/dto/create-testimony.dto.ts
+++ b/beland-backend/src/testimonies/dto/create-testimony.dto.ts
@@ -1,0 +1,32 @@
+// src/testimonies/dto/create-testimony.dto.ts
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsString,
+  IsNotEmpty,
+  IsInt,
+  IsOptional,
+  Min,
+  Max,
+} from 'class-validator';
+
+export class CreateTestimonyDto {
+  @ApiProperty({
+    description: 'Contenido del testimonio.',
+    minLength: 10,
+    maxLength: 500,
+  })
+  @IsString({ message: 'El contenido debe ser una cadena de texto.' })
+  @IsNotEmpty({ message: 'El contenido del testimonio no puede estar vacío.' })
+  // Puedes ajustar MinLength y MaxLength según tus requisitos
+  content: string;
+
+  @ApiPropertyOptional({
+    description: 'Calificación del testimonio (ej. 1-5 estrellas).',
+    nullable: true,
+  })
+  @IsOptional()
+  @IsInt({ message: 'La calificación debe ser un número entero.' })
+  @Min(1, { message: 'La calificación mínima es 1.' })
+  @Max(5, { message: 'La calificación máxima es 5.' })
+  rating?: number;
+}

--- a/beland-backend/src/testimonies/dto/get-testimonies-query.dto.ts
+++ b/beland-backend/src/testimonies/dto/get-testimonies-query.dto.ts
@@ -1,0 +1,94 @@
+// src/testimonies/dto/get-testimonies-query.dto.ts
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsBoolean,
+  IsOptional,
+  IsString,
+  IsUUID,
+  IsInt,
+  Min,
+} from 'class-validator'; // Importar IsInt, Min
+import { Type } from 'class-transformer';
+// No necesitamos extender de PaginationDto si definimos limit/offset aquí,
+// pero si PaginationDto tiene otras lógicas que quieres heredar, puedes mantenerlo.
+// Para este error específico, la re-declaración es la clave.
+
+// Si PaginationDto no tiene otras propiedades o lógica compleja, podrías simplemente no extenderlo y definir todo aquí.
+// Sin embargo, por consistencia, mantendremos la extensión y re-declararemos para mayor claridad.
+// import { PaginationDto } from 'src/common/dto/pagination.dto'; // Mantenemos si aún se extiende
+
+export class GetTestimoniesQueryDto {
+  // Si no extiendes PaginationDto, elimina "extends PaginationDto"
+
+  @ApiPropertyOptional({
+    description: 'Límite de resultados por página.',
+    default: 10,
+    type: Number,
+  })
+  @IsOptional()
+  @IsInt({ message: 'El límite debe ser un número entero.' })
+  @Min(1, { message: 'El límite debe ser al menos 1.' })
+  @Type(() => Number)
+  limit?: number; // Explícitamente declarado
+
+  @ApiPropertyOptional({
+    description: 'Número de elementos a omitir (offset).',
+    default: 0,
+    type: Number,
+  })
+  @IsOptional()
+  @IsInt({ message: 'El offset debe ser un número entero.' })
+  @Min(0, { message: 'El offset debe ser al menos 0.' })
+  @Type(() => Number)
+  offset?: number; // Explícitamente declarado
+
+  @ApiPropertyOptional({
+    description: 'Filtrar testimonios por ID de usuario que lo creó.',
+    type: String,
+    format: 'uuid',
+  })
+  @IsOptional()
+  @IsUUID()
+  userId?: string;
+
+  @ApiPropertyOptional({
+    description: 'Filtrar por testimonios aprobados (true/false).',
+    type: Boolean,
+  })
+  @IsOptional()
+  @IsBoolean()
+  @Type(() => Boolean) // Asegura la conversión a booleano
+  isApproved?: boolean;
+
+  @ApiPropertyOptional({
+    description:
+      'Incluir testimonios eliminados lógicamente (solo para administradores).',
+    type: Boolean,
+  })
+  @IsOptional()
+  @IsBoolean()
+  @Type(() => Boolean) // Asegura la conversión a booleano
+  includeDeleted?: boolean;
+
+  @ApiPropertyOptional({
+    description:
+      'Ordenar por un campo específico (ej. "created_at", "rating").',
+    type: String,
+    enum: ['created_at', 'rating', 'user.full_name'], // Añadir campos válidos para ordenar
+    example: 'created_at',
+  })
+  @IsOptional()
+  @IsString()
+  orderBy?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Orden de clasificación (ASC para ascendente, DESC para descendente).',
+    type: String,
+    enum: ['ASC', 'DESC'],
+    example: 'DESC',
+  })
+  @IsOptional()
+  @IsString()
+  order?: 'ASC' | 'DESC';
+}

--- a/beland-backend/src/testimonies/dto/testimony.dto.ts
+++ b/beland-backend/src/testimonies/dto/testimony.dto.ts
@@ -1,0 +1,75 @@
+// src/testimonies/dto/testimony.dto.ts
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsUUID,
+  IsString,
+  IsBoolean,
+  IsInt,
+  IsOptional,
+  IsDate,
+  ValidateNested,
+  Min,
+  Max,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { UserDto } from 'src/users/dto/user.dto'; // Asume que tienes un UserDto para mostrar la info del autor
+
+export class TestimonyDto {
+  @ApiProperty({ description: 'ID único del testimonio.', format: 'uuid' })
+  @IsUUID()
+  id: string;
+
+  @ApiProperty({ description: 'Contenido del testimonio.' })
+  @IsString()
+  content: string;
+
+  @ApiPropertyOptional({
+    description: 'Calificación del testimonio (ej. 1-5).',
+    nullable: true,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(5)
+  rating?: number;
+
+  @ApiProperty({ description: 'Estado de aprobación del testimonio.' })
+  @IsBoolean()
+  is_approved: boolean;
+
+  @ApiProperty({
+    description: 'ID del usuario que escribió el testimonio.',
+    format: 'uuid',
+  })
+  @IsUUID()
+  user_id: string;
+
+  @ApiProperty({
+    description: 'Información del usuario que escribió el testimonio.',
+    type: () => UserDto,
+  })
+  @ValidateNested()
+  @Type(() => UserDto)
+  user: UserDto;
+
+  @ApiProperty({ description: 'Fecha y hora de creación del testimonio.' })
+  @IsDate()
+  @Type(() => Date)
+  created_at: Date;
+
+  @ApiProperty({
+    description: 'Fecha y hora de la última actualización del testimonio.',
+  })
+  @IsDate()
+  @Type(() => Date)
+  updated_at: Date;
+
+  @ApiPropertyOptional({
+    description: 'Fecha y hora de eliminación lógica del testimonio.',
+    nullable: true,
+  })
+  @IsOptional()
+  @IsDate()
+  @Type(() => Date)
+  deleted_at?: Date;
+}

--- a/beland-backend/src/testimonies/dto/update-testimony.dto.ts
+++ b/beland-backend/src/testimonies/dto/update-testimony.dto.ts
@@ -1,0 +1,12 @@
+// src/testimonies/dto/update-testimony.dto.ts
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateTestimonyDto } from './create-testimony.dto';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsBoolean, IsOptional } from 'class-validator';
+
+export class UpdateTestimonyDto extends PartialType(CreateTestimonyDto) {
+  @ApiPropertyOptional({ description: 'Estado de aprobación del testimonio.' })
+  @IsOptional()
+  @IsBoolean({ message: 'is_approved debe ser un valor booleano.' })
+  is_approved?: boolean;
+}

--- a/beland-backend/src/testimonies/entities/testimony.entity.ts
+++ b/beland-backend/src/testimonies/entities/testimony.entity.ts
@@ -1,0 +1,44 @@
+// src/testimonies/entities/testimony.entity.ts
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  DeleteDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { User } from 'src/users/entities/users.entity'; // Importa la entidad User
+
+@Entity('testimonies') // Nombre de la tabla en la base de datos
+export class Testimony {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'text', nullable: false })
+  content: string; // El contenido del testimonio
+
+  @Column({ type: 'int', nullable: true })
+  rating?: number; // Calificación opcional (ej. 1-5 estrellas)
+
+  @Column({ type: 'boolean', default: false })
+  is_approved: boolean; // Indica si el testimonio ha sido aprobado por un administrador
+
+  @Column({ type: 'uuid', nullable: false })
+  user_id: string; // ID del usuario que escribió el testimonio
+
+  @CreateDateColumn({ type: 'timestamp' })
+  created_at: Date;
+
+  @UpdateDateColumn({ type: 'timestamp' })
+  updated_at: Date;
+
+  @DeleteDateColumn({ type: 'timestamp', nullable: true })
+  deleted_at: Date; // Para soft-delete
+
+  // Relación ManyToOne con User (un usuario puede tener muchos testimonios)
+  @ManyToOne(() => User, (user) => user.testimonies, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user: User; // Objeto del usuario relacionado
+}

--- a/beland-backend/src/testimonies/testimonies.controller.spec.ts
+++ b/beland-backend/src/testimonies/testimonies.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TestimoniesController } from './testimonies.controller';
+import { TestimoniesService } from './testimonies.service';
+
+describe('TestimoniesController', () => {
+  let controller: TestimoniesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TestimoniesController],
+      providers: [TestimoniesService],
+    }).compile();
+
+    controller = module.get<TestimoniesController>(TestimoniesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/beland-backend/src/testimonies/testimonies.controller.ts
+++ b/beland-backend/src/testimonies/testimonies.controller.ts
@@ -1,0 +1,438 @@
+// src/testimonies/testimony.controller.ts
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  Query,
+  Req,
+  HttpCode,
+  HttpStatus,
+  UseGuards,
+  ForbiddenException,
+  BadRequestException,
+  ParseUUIDPipe,
+  Logger,
+  InternalServerErrorException,
+  ConflictException,
+  NotFoundException,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
+import { CreateTestimonyDto } from './dto/create-testimony.dto';
+import { UpdateTestimonyDto } from './dto/update-testimony.dto';
+import { TestimonyDto } from './dto/testimony.dto';
+import { GetTestimoniesQueryDto } from './dto/get-testimonies-query.dto';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+  ApiQuery,
+  ApiBody,
+} from '@nestjs/swagger';
+import { FlexibleAuthGuard } from 'src/auth/guards/flexible-auth.guard';
+import { RolesGuard } from 'src/auth/guards/roles.guard';
+import { Roles } from 'src/auth/decorators/roles.decorator';
+import { User } from 'src/users/entities/users.entity';
+import { Request } from 'express';
+import { TestimoniesService } from './testimonies.service';
+
+@ApiTags('testimonies')
+@Controller('testimonies')
+@UsePipes(
+  new ValidationPipe({
+    whitelist: true,
+    forbidNonWhitelisted: true,
+    transform: true,
+  }),
+)
+export class TestimoniesController {
+  private readonly logger = new Logger(TestimoniesController.name);
+
+  constructor(private readonly testimoniesService: TestimoniesService) {}
+
+  /**
+   * Helper para extraer el ID del usuario autenticado de la solicitud.
+   * Maneja tanto el 'id' (cuando el objeto User completo es adjuntado)
+   * como el 'sub' (cuando el payload del JWT es adjuntado).
+   * @param req El objeto de la solicitud Express.
+   * @returns El ID del usuario.
+   * @throws ForbiddenException si el ID del usuario no puede ser determinado.
+   */
+  private getUserId(req: Request): string {
+    const user = req.user as any; // Usar 'any' para acceder flexiblemente a 'id' o 'sub'
+    const userId = user?.id || user?.sub; // Primero intenta 'id', luego 'sub'
+
+    if (!userId) {
+      this.logger.error(
+        'getUserId(): No se pudo determinar el ID del usuario autenticado (ni .id ni .sub encontrados en req.user).',
+      );
+      throw new ForbiddenException(
+        'No se pudo determinar el ID del usuario autenticado para esta operación. Acceso denegado.',
+      );
+    }
+    return userId;
+  }
+
+  /**
+   * Helper para obtener el rol del usuario autenticado de la solicitud.
+   * @param req El objeto de la solicitud Express.
+   * @returns El nombre del rol del usuario.
+   * @throws ForbiddenException si el rol del usuario no puede ser determinado.
+   */
+  private getUserRole(req: Request): string {
+    const user = req.user as User;
+    const userRole = user?.role_name;
+
+    if (!userRole) {
+      this.logger.error(
+        'getUserRole(): No se pudo determinar el rol del usuario autenticado (role_name no encontrado en req.user).',
+      );
+      throw new ForbiddenException(
+        'No se pudo determinar el rol del usuario autenticado para esta operación. Acceso denegado.',
+      );
+    }
+    return userRole;
+  }
+
+  @Post()
+  @UseGuards(FlexibleAuthGuard) // Solo usuarios autenticados pueden crear testimonios
+  @ApiBearerAuth('JWT-auth')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Crea un nuevo testimonio.' })
+  @ApiBody({ type: CreateTestimonyDto })
+  @ApiResponse({
+    status: 201,
+    description: 'Testimonio creado y pendiente de aprobación.',
+    type: TestimonyDto,
+  })
+  @ApiResponse({ status: 400, description: 'Datos de entrada inválidos.' })
+  @ApiResponse({ status: 401, description: 'No autenticado.' })
+  @ApiResponse({ status: 404, description: 'Usuario no encontrado.' })
+  @ApiResponse({
+    status: 409,
+    description: 'Conflicto (ej. ya envió un testimonio).',
+  })
+  async create(
+    @Body() createTestimonyDto: CreateTestimonyDto,
+    @Req() req: Request,
+  ): Promise<TestimonyDto> {
+    const userId = this.getUserId(req);
+    this.logger.log(
+      `POST /testimonies: Solicitud para crear testimonio por usuario ID: ${userId}`,
+    );
+    try {
+      return await this.testimoniesService.create(createTestimonyDto, userId);
+    } catch (error) {
+      this.logger.error(
+        `Error al crear testimonio: ${(error as Error).message}`,
+        (error as Error).stack,
+      );
+      if (
+        error instanceof NotFoundException ||
+        error instanceof BadRequestException ||
+        error instanceof ConflictException
+      ) {
+        throw error;
+      }
+      throw new InternalServerErrorException('Fallo al crear el testimonio.');
+    }
+  }
+
+  @Get()
+  @UseGuards(FlexibleAuthGuard) // Puede ser accedido por usuarios autenticados para ver todos o públicos para ver solo aprobados
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary:
+      'Obtiene todos los testimonios. Los usuarios no autenticados solo ven aprobados.',
+    description:
+      'Los administradores pueden ver todos los testimonios (incluyendo pendientes y eliminados) aplicando los filtros `isApproved` y `includeDeleted`. Los usuarios normales solo ven testimonios aprobados.',
+  })
+  @ApiQuery({ type: GetTestimoniesQueryDto, required: false })
+  @ApiResponse({
+    status: 200,
+    description: 'Lista de testimonios obtenida exitosamente.',
+    type: [TestimonyDto],
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'No autenticado si se intenta usar filtros de admin sin rol.',
+  })
+  async findAll(
+    @Query() query: GetTestimoniesQueryDto,
+    @Req() req: Request,
+  ): Promise<{ testimonies: TestimonyDto[]; total: number }> {
+    const userId = this.getUserId(req);
+    const userRole = this.getUserRole(req);
+    this.logger.log(
+      `GET /testimonies: Solicitud para obtener todos los testimonios por usuario ID: ${userId} (Rol: ${userRole})`,
+    );
+    try {
+      return await this.testimoniesService.findAll(query, userId, userRole);
+    } catch (error) {
+      this.logger.error(
+        `Error al obtener testimonios: ${(error as Error).message}`,
+        (error as Error).stack,
+      );
+      throw new InternalServerErrorException(
+        'Fallo al obtener los testimonios.',
+      );
+    }
+  }
+
+  @Get(':id')
+  @UseGuards(FlexibleAuthGuard) // Puede ser accedido por usuario autenticado (propietario) o admin, o público si está aprobado
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary:
+      'Obtiene un testimonio por su ID. Requiere permisos si no está aprobado.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'ID del testimonio (UUID).',
+    type: String,
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Testimonio obtenido exitosamente.',
+    type: TestimonyDto,
+  })
+  @ApiResponse({ status: 401, description: 'No autenticado.' })
+  @ApiResponse({ status: 403, description: 'No autorizado.' })
+  @ApiResponse({ status: 404, description: 'Testimonio no encontrado.' })
+  async findOne(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Req() req: Request,
+  ): Promise<TestimonyDto> {
+    const userId = this.getUserId(req);
+    const userRole = this.getUserRole(req);
+    this.logger.log(
+      `GET /testimonies/${id}: Solicitud para obtener testimonio por ID: ${id} por usuario ID: ${userId} (Rol: ${userRole})`,
+    );
+    try {
+      return await this.testimoniesService.findOne(id, userId, userRole);
+    } catch (error) {
+      this.logger.error(
+        `Error al obtener testimonio ID: ${id}: ${(error as Error).message}`,
+        (error as Error).stack,
+      );
+      if (
+        error instanceof NotFoundException ||
+        error instanceof ForbiddenException
+      ) {
+        throw error;
+      }
+      throw new InternalServerErrorException('Fallo al obtener el testimonio.');
+    }
+  }
+
+  @Patch(':id')
+  @UseGuards(FlexibleAuthGuard) // Solo el autor o ADMIN/SUPERADMIN puede actualizar
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary:
+      'Actualiza un testimonio por su ID (solo autor o ADMIN/SUPERADMIN).',
+    description:
+      'El autor solo puede modificar `content` y `rating`. Los administradores pueden modificar `is_approved` además de otros campos.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'ID del testimonio a actualizar (UUID).',
+    type: String,
+  })
+  @ApiBody({ type: UpdateTestimonyDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Testimonio actualizado exitosamente.',
+    type: TestimonyDto,
+  })
+  @ApiResponse({ status: 400, description: 'Datos de entrada inválidos.' })
+  @ApiResponse({ status: 401, description: 'No autenticado.' })
+  @ApiResponse({ status: 403, description: 'No autorizado.' })
+  @ApiResponse({ status: 404, description: 'Testimonio no encontrado.' })
+  async update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() updateTestimonyDto: UpdateTestimonyDto,
+    @Req() req: Request,
+  ): Promise<TestimonyDto> {
+    const userId = this.getUserId(req);
+    const userRole = this.getUserRole(req);
+    this.logger.log(
+      `PATCH /testimonies/${id}: Solicitud para actualizar testimonio ID: ${id} por usuario ID: ${userId} (Rol: ${userRole})`,
+    );
+    try {
+      return await this.testimoniesService.update(
+        id,
+        updateTestimonyDto,
+        userId,
+        userRole,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Error al actualizar testimonio ID: ${id}: ${(error as Error).message}`,
+        (error as Error).stack,
+      );
+      if (
+        error instanceof NotFoundException ||
+        error instanceof ForbiddenException ||
+        error instanceof BadRequestException
+      ) {
+        throw error;
+      }
+      throw new InternalServerErrorException(
+        'Fallo al actualizar el testimonio.',
+      );
+    }
+  }
+
+  @Patch(':id/approve')
+  @Roles('ADMIN', 'SUPERADMIN') // Solo ADMIN/SUPERADMIN pueden aprobar testimonios
+  @UseGuards(FlexibleAuthGuard, RolesGuard)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({ summary: 'Aprueba un testimonio (solo ADMIN/SUPERADMIN).' })
+  @ApiParam({
+    name: 'id',
+    description: 'ID del testimonio a aprobar (UUID).',
+    type: String,
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Testimonio aprobado exitosamente.',
+    type: TestimonyDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Testimonio ya aprobado o inválido.',
+  })
+  @ApiResponse({ status: 401, description: 'No autenticado.' })
+  @ApiResponse({
+    status: 403,
+    description: 'No autorizado (rol insuficiente).',
+  })
+  @ApiResponse({ status: 404, description: 'Testimonio no encontrado.' })
+  async approve(@Param('id', ParseUUIDPipe) id: string): Promise<TestimonyDto> {
+    this.logger.log(
+      `PATCH /testimonies/${id}/approve: Solicitud para aprobar testimonio ID: ${id}`,
+    );
+    try {
+      return await this.testimoniesService.approveTestimony(id);
+    } catch (error) {
+      this.logger.error(
+        `Error al aprobar testimonio ID: ${id}: ${(error as Error).message}`,
+        (error as Error).stack,
+      );
+      if (
+        error instanceof NotFoundException ||
+        error instanceof BadRequestException
+      ) {
+        throw error;
+      }
+      throw new InternalServerErrorException('Fallo al aprobar el testimonio.');
+    }
+  }
+
+  @Delete(':id')
+  @UseGuards(FlexibleAuthGuard) // Solo el autor o ADMIN/SUPERADMIN puede soft-eliminar
+  @ApiBearerAuth('JWT-auth')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary:
+      'Realiza un soft delete de un testimonio (solo autor o ADMIN/SUPERADMIN).',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'ID del testimonio a eliminar lógicamente (UUID).',
+    type: String,
+  })
+  @ApiResponse({
+    status: 204,
+    description: 'Testimonio eliminado lógicamente.',
+  })
+  @ApiResponse({ status: 400, description: 'Testimonio ya eliminado.' })
+  @ApiResponse({ status: 401, description: 'No autenticado.' })
+  @ApiResponse({ status: 403, description: 'No autorizado.' })
+  @ApiResponse({ status: 404, description: 'Testimonio no encontrado.' })
+  async softDelete(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Req() req: Request,
+  ): Promise<void> {
+    const userId = this.getUserId(req);
+    const userRole = this.getUserRole(req);
+    this.logger.log(
+      `DELETE /testimonies/${id}: Solicitud de soft-delete para testimonio ID: ${id} por usuario ID: ${userId} (Rol: ${userRole})`,
+    );
+    try {
+      await this.testimoniesService.softDelete(id, userId, userRole);
+    } catch (error) {
+      this.logger.error(
+        `Error al soft-eliminar testimonio ID: ${id}: ${
+          (error as Error).message
+        }`,
+        (error as Error).stack,
+      );
+      if (
+        error instanceof NotFoundException ||
+        error instanceof ForbiddenException ||
+        error instanceof BadRequestException
+      ) {
+        throw error;
+      }
+      throw new InternalServerErrorException(
+        'Fallo al eliminar lógicamente el testimonio.',
+      );
+    }
+  }
+
+  @Delete(':id/hard')
+  @Roles('SUPERADMIN') // Solo SUPERADMIN puede hard-eliminar
+  @UseGuards(FlexibleAuthGuard, RolesGuard)
+  @ApiBearerAuth('JWT-auth')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: 'ELIMINA PERMANENTEMENTE un testimonio por ID (solo SUPERADMIN).',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'ID del testimonio a eliminar permanentemente (UUID).',
+    type: String,
+  })
+  @ApiResponse({
+    status: 204,
+    description: 'Testimonio eliminado permanentemente.',
+  })
+  @ApiResponse({ status: 401, description: 'No autenticado.' })
+  @ApiResponse({
+    status: 403,
+    description: 'No autorizado (rol insuficiente).',
+  })
+  @ApiResponse({ status: 404, description: 'Testimonio no encontrado.' })
+  async hardDelete(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
+    this.logger.warn(
+      `DELETE /testimonies/${id}/hard: Solicitud de hard-delete para testimonio ID: ${id} (SOLO SUPERADMIN)`,
+    );
+    try {
+      await this.testimoniesService.hardDelete(id);
+    } catch (error) {
+      this.logger.error(
+        `Error al hard-eliminar testimonio ID: ${id}: ${
+          (error as Error).message
+        }`,
+        (error as Error).stack,
+      );
+      if (
+        error instanceof NotFoundException ||
+        error instanceof ForbiddenException
+      ) {
+        throw error;
+      }
+      throw new InternalServerErrorException(
+        'Fallo al eliminar permanentemente el testimonio.',
+      );
+    }
+  }
+}

--- a/beland-backend/src/testimonies/testimonies.module.ts
+++ b/beland-backend/src/testimonies/testimonies.module.ts
@@ -1,0 +1,20 @@
+// src/testimonies/testimony.module.ts
+import { Module, forwardRef } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Testimony } from './entities/testimony.entity';
+import { TestimonyRepository } from './testimony.repository';
+import { UsersModule } from 'src/users/users.module'; // Importa UsersModule para UsersService
+import { User } from 'src/users/entities/users.entity'; // Importa User para TypeOrmModule.forFeature
+import { TestimoniesController } from './testimonies.controller';
+import { TestimoniesService } from './testimonies.service';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Testimony, User]), // Registra la entidad Testimony y User
+    forwardRef(() => UsersModule), // Para resolver dependencias circulares con UsersModule
+  ],
+  controllers: [TestimoniesController],
+  providers: [TestimoniesService, TestimonyRepository],
+  exports: [TestimoniesService, TestimonyRepository, TypeOrmModule], // Exporta para que otros módulos puedan usarlos
+})
+export class TestimoniesModule {}

--- a/beland-backend/src/testimonies/testimonies.service.spec.ts
+++ b/beland-backend/src/testimonies/testimonies.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TestimoniesService } from './testimonies.service';
+
+describe('TestimoniesService', () => {
+  let service: TestimoniesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [TestimoniesService],
+    }).compile();
+
+    service = module.get<TestimoniesService>(TestimoniesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/beland-backend/src/testimonies/testimonies.service.ts
+++ b/beland-backend/src/testimonies/testimonies.service.ts
@@ -1,0 +1,325 @@
+// src/testimonies/testimony.service.ts
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  ConflictException,
+  Logger,
+  InternalServerErrorException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { TestimonyRepository } from './testimony.repository';
+import { UsersService } from 'src/users/users.service';
+import { CreateTestimonyDto } from './dto/create-testimony.dto';
+import { UpdateTestimonyDto } from './dto/update-testimony.dto';
+import { TestimonyDto } from './dto/testimony.dto'; // Importación correcta (singular)
+import { Testimony } from './entities/testimony.entity';
+import { plainToInstance } from 'class-transformer';
+import { DataSource } from 'typeorm';
+import { GetTestimoniesQueryDto } from './dto/get-testimonies-query.dto';
+
+// Constantes de roles para verificación
+const ROLE_ADMIN = 'ADMIN';
+const ROLE_SUPERADMIN = 'SUPERADMIN';
+
+@Injectable()
+export class TestimoniesService {
+  private readonly logger = new Logger(TestimoniesService.name);
+
+  constructor(
+    private readonly testimonyRepository: TestimonyRepository,
+    private readonly usersService: UsersService, // Para verificar que el usuario existe y para obtener su rol
+    private dataSource: DataSource, // Para transacciones
+  ) {}
+
+  /**
+   * Crea un nuevo testimonio.
+   * @param createTestimonyDto Datos para crear el testimonio.
+   * @param userId ID del usuario autenticado que crea el testimonio.
+   * @returns El TestimonioDto creado.
+   * @throws NotFoundException si el usuario no existe.
+   * @throws BadRequestException si el usuario ya ha enviado un testimonio y no puede enviar otro.
+   */
+  async create(
+    createTestimonyDto: CreateTestimonyDto,
+    userId: string,
+  ): Promise<TestimonyDto> {
+    this.logger.debug(
+      `create(): Intentando crear testimonio para usuario ID: ${userId}`,
+    );
+
+    // Verificar si el usuario existe
+    const user = await this.usersService.findUserEntityById(userId); // Usar el método que devuelve la entidad User
+    if (!user) {
+      throw new NotFoundException(`Usuario con ID "${userId}" no encontrado.`);
+    }
+
+    // Opcional: Impedir que un usuario envíe múltiples testimonios (si es tu lógica de negocio)
+    // Puedes buscar si ya existe un testimonio activo para este usuario
+    const existingTestimonies = await this.testimonyRepository.findAllPaginated(
+      { userId: userId, isApproved: false, includeDeleted: false }, // Añadir userId al DTO de consulta
+    );
+    if (existingTestimonies.total > 0) {
+      throw new BadRequestException(
+        'Ya has enviado un testimonio. No puedes enviar más de uno.',
+      );
+    }
+
+    const newTestimony = this.testimonyRepository.createTestimony({
+      ...createTestimonyDto,
+      user_id: userId,
+      user: user, // Asigna la entidad de usuario
+      is_approved: false, // Por defecto, el testimonio requiere aprobación
+    });
+
+    const savedTestimony = await this.testimonyRepository.saveTestimony(
+      newTestimony,
+    );
+    this.logger.log(
+      `create(): Testimonio ID: ${savedTestimony.id} creado por usuario ID: ${userId}. Pendiente de aprobación.`,
+    );
+    return plainToInstance(TestimonyDto, savedTestimony);
+  }
+
+  /**
+   * Obtiene todos los testimonios paginados y filtrados.
+   * @param queryDto DTO con parámetros de paginación, filtro y ordenación.
+   * @param currentUserId ID del usuario autenticado (para verificar permisos).
+   * @param currentUserRole Rol del usuario autenticado.
+   * @returns Un objeto con la lista de TestimonioDto y el total.
+   */
+  async findAll(
+    queryDto: GetTestimoniesQueryDto,
+    currentUserId: string,
+    currentUserRole: string,
+  ): Promise<{ testimonies: TestimonyDto[]; total: number }> {
+    this.logger.debug(
+      `findAll(): Buscando testimonios con filtros: ${JSON.stringify(
+        queryDto,
+      )}`,
+    );
+
+    const isSuperAdminOrAdmin =
+      currentUserRole === ROLE_ADMIN || currentUserRole === ROLE_SUPERADMIN;
+
+    // Lógica para determinar si se deben incluir testimonios eliminados (soft-deleted)
+    // Solo admins/superadmins pueden verlos si lo solicitan.
+    const finalIncludeDeleted = isSuperAdminOrAdmin
+      ? queryDto.includeDeleted
+      : false;
+    queryDto.includeDeleted = finalIncludeDeleted;
+
+    // Por defecto, los usuarios normales solo ven testimonios aprobados
+    if (!isSuperAdminOrAdmin && queryDto.isApproved === undefined) {
+      queryDto.isApproved = true;
+    }
+
+    const { testimonies, total } =
+      await this.testimonyRepository.findAllPaginated(queryDto);
+
+    const testimoniesDto = plainToInstance(TestimonyDto, testimonies);
+    this.logger.log(`findAll(): Se encontraron ${total} testimonios.`);
+    return { testimonies: testimoniesDto, total };
+  }
+
+  /**
+   * Obtiene un testimonio por su ID.
+   * @param id El ID del testimonio.
+   * @param currentUserId ID del usuario autenticado (para verificar propiedad).
+   * @param currentUserRole Rol del usuario autenticado.
+   * @returns El TestimonioDto encontrado.
+   * @throws NotFoundException si el testimonio no se encuentra.
+   * @throws ForbiddenException si el usuario no tiene permisos para ver el testimonio.
+   */
+  async findOne(
+    id: string,
+    currentUserId: string,
+    currentUserRole: string,
+  ): Promise<TestimonyDto> {
+    this.logger.debug(
+      `findOne(): Buscando testimonio con ID: ${id} para usuario ID: ${currentUserId}`,
+    );
+
+    const isSuperAdminOrAdmin =
+      currentUserRole === ROLE_ADMIN || currentUserRole === ROLE_SUPERADMIN;
+    const testimony = await this.testimonyRepository.findOneById(
+      id,
+      isSuperAdminOrAdmin,
+    ); // Admin puede ver soft-deleted
+
+    if (!testimony) {
+      throw new NotFoundException(`Testimonio con ID "${id}" no encontrado.`);
+    }
+
+    // Si no es admin/superadmin, el testimonio debe estar aprobado o ser del propio usuario
+    if (
+      !isSuperAdminOrAdmin &&
+      !testimony.is_approved &&
+      testimony.user_id !== currentUserId
+    ) {
+      throw new ForbiddenException(
+        'No tienes permisos para ver este testimonio.',
+      );
+    }
+
+    this.logger.log(`findOne(): Testimonio ID: ${id} encontrado.`);
+    return plainToInstance(TestimonyDto, testimony);
+  }
+
+  /**
+   * Actualiza un testimonio por su ID.
+   * @param id El ID del testimonio a actualizar.
+   * @param updateTestimonyDto Datos para actualizar el testimonio.
+   * @param currentUserId ID del usuario que realiza la operación.
+   * @param currentUserRole Rol del usuario que realiza la operación.
+   * @returns El TestimonioDto actualizado.
+   * @throws NotFoundException si el testimonio no se encuentra.
+   * @throws ForbiddenException si el usuario no tiene permisos para actualizar el testimonio.
+   */
+  async update(
+    id: string,
+    updateTestimonyDto: UpdateTestimonyDto,
+    currentUserId: string,
+    currentUserRole: string,
+  ): Promise<TestimonyDto> {
+    this.logger.debug(
+      `update(): Actualizando testimonio ID: ${id} por usuario ID: ${currentUserId}`,
+    );
+
+    const isSuperAdminOrAdmin =
+      currentUserRole === ROLE_ADMIN || currentUserRole === ROLE_SUPERADMIN;
+    const testimonyToUpdate = await this.testimonyRepository.findOneById(
+      id,
+      true,
+    ); // Admin puede ver soft-deleted
+
+    if (!testimonyToUpdate) {
+      throw new NotFoundException(`Testimonio con ID "${id}" no encontrado.`);
+    }
+
+    // Solo el autor del testimonio o un ADMIN/SUPERADMIN pueden actualizarlo
+    if (testimonyToUpdate.user_id !== currentUserId && !isSuperAdminOrAdmin) {
+      throw new ForbiddenException(
+        'No tienes permisos para actualizar este testimonio.',
+      );
+    }
+
+    // Si el usuario intenta cambiar 'is_approved' y no es admin, lanza error
+    if (updateTestimonyDto.is_approved !== undefined && !isSuperAdminOrAdmin) {
+      throw new ForbiddenException(
+        'Solo un administrador puede cambiar el estado de aprobación del testimonio.',
+      );
+    }
+
+    // Aplicar los cambios
+    Object.assign(testimonyToUpdate, updateTestimonyDto);
+
+    const updatedTestimony = await this.testimonyRepository.saveTestimony(
+      testimonyToUpdate,
+    );
+    this.logger.log(`update(): Testimonio ID: ${id} actualizado exitosamente.`);
+    return plainToInstance(TestimonyDto, updatedTestimony);
+  }
+
+  /**
+   * Aprueba un testimonio (solo para administradores).
+   * @param id El ID del testimonio a aprobar.
+   * @returns El TestimonioDto aprobado.
+   * @throws NotFoundException si el testimonio no se encuentra.
+   * @throws BadRequestException si el testimonio ya está aprobado.
+   */
+  async approveTestimony(id: string): Promise<TestimonyDto> {
+    this.logger.debug(`approveTestimony(): Aprobando testimonio ID: ${id}`);
+
+    const testimonyToApprove = await this.testimonyRepository.findOneById(id);
+
+    if (!testimonyToApprove) {
+      throw new NotFoundException(`Testimonio con ID "${id}" no encontrado.`);
+    }
+    if (testimonyToApprove.is_approved) {
+      throw new BadRequestException(
+        `El testimonio con ID "${id}" ya está aprobado.`,
+      );
+    }
+
+    testimonyToApprove.is_approved = true;
+    const approvedTestimony = await this.testimonyRepository.saveTestimony(
+      testimonyToApprove,
+    );
+    this.logger.log(
+      `approveTestimony(): Testimonio ID: ${id} aprobado exitosamente.`,
+    );
+    return plainToInstance(TestimonyDto, approvedTestimony); // <-- Corregido aquí
+  }
+
+  /**
+   * Realiza un "soft delete" en un testimonio.
+   * Solo el autor o un ADMIN/SUPERADMIN puede eliminar lógicamente.
+   * @param id El ID del testimonio a desactivar.
+   * @param currentUserId ID del usuario que realiza la operación.
+   * @param currentUserRole Rol del usuario que realiza la operación.
+   * @throws NotFoundException si el testimonio no se encuentra.
+   * @throws ForbiddenException si el usuario no tiene permisos.
+   * @throws BadRequestException si el testimonio ya está eliminado.
+   */
+  async softDelete(
+    id: string,
+    currentUserId: string,
+    currentUserRole: string,
+  ): Promise<void> {
+    this.logger.debug(
+      `softDelete(): Soft-eliminando testimonio ID: ${id} por usuario ID: ${currentUserId}`,
+    );
+
+    const isSuperAdminOrAdmin =
+      currentUserRole === ROLE_ADMIN || currentUserRole === ROLE_SUPERADMIN;
+    const testimonyToDelete = await this.testimonyRepository.findOneById(
+      id,
+      false,
+    ); // No incluir soft-deleted para esta comprobación
+
+    if (!testimonyToDelete) {
+      throw new NotFoundException(`Testimonio con ID "${id}" no encontrado.`);
+    }
+    if (testimonyToDelete.deleted_at !== null) {
+      throw new BadRequestException(
+        `El testimonio con ID "${id}" ya está eliminado.`,
+      );
+    }
+
+    // Solo el autor o un ADMIN/SUPERADMIN pueden eliminar
+    if (testimonyToDelete.user_id !== currentUserId && !isSuperAdminOrAdmin) {
+      throw new ForbiddenException(
+        'No tienes permisos para eliminar este testimonio.',
+      );
+    }
+
+    await this.testimonyRepository.softDeleteTestimony(id);
+    this.logger.log(
+      `softDelete(): Testimonio ID: ${id} soft-eliminado exitosamente.`,
+    );
+  }
+
+  /**
+   * Elimina permanentemente un testimonio de la base de datos (hard delete).
+   * Solo SUPERADMIN puede realizar esta operación.
+   * @param id El ID del testimonio a eliminar.
+   * @throws NotFoundException si el testimonio no se encuentra.
+   * @throws ForbiddenException si el usuario no es SUPERADMIN.
+   */
+  async hardDelete(id: string): Promise<void> {
+    this.logger.warn(
+      `hardDelete(): Intentando eliminar permanentemente el testimonio ID: ${id}`,
+    );
+
+    const testimony = await this.testimonyRepository.findOneById(id, true); // Incluir soft-deleted para hard delete
+    if (!testimony) {
+      throw new NotFoundException(`Testimonio con ID "${id}" no encontrado.`);
+    }
+
+    await this.testimonyRepository.hardDeleteTestimony(id);
+    this.logger.log(
+      `hardDelete(): Testimonio ID: ${id} eliminado permanentemente.`,
+    );
+  }
+}

--- a/beland-backend/src/testimonies/testimony.repository.ts
+++ b/beland-backend/src/testimonies/testimony.repository.ts
@@ -1,0 +1,176 @@
+// src/testimonies/testimony.repository.ts
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import {
+  Repository,
+  DataSource,
+  FindOptionsWhere,
+  LessThanOrEqual,
+  IsNull,
+  Not,
+} from 'typeorm';
+import { Testimony } from './entities/testimony.entity';
+import { GetTestimoniesQueryDto } from './dto/get-testimonies-query.dto'; // Usa este DTO
+
+@Injectable()
+export class TestimonyRepository extends Repository<Testimony> {
+  private readonly logger = new Logger(TestimonyRepository.name);
+
+  constructor(
+    @InjectRepository(Testimony)
+    private readonly testimonyORMRepository: Repository<Testimony>,
+    private dataSource: DataSource,
+  ) {
+    super(Testimony, dataSource.createEntityManager());
+  }
+
+  /**
+   * Helper para crear un query builder con cargas ansiosas comunes para Testimony y sus relaciones.
+   * Esto asegura que cuando se busca un testimonio, el usuario que lo escribió también se cargue.
+   * @param alias El alias para la entidad Testimony en la consulta.
+   * @param includeDeleted Si se deben incluir los testimonios marcados como eliminados (soft-deleted).
+   * @returns Una instancia de TypeORM QueryBuilder.
+   */
+  private createQueryBuilderWithRelations(
+    alias = 'testimony',
+    includeDeleted: boolean = false,
+  ) {
+    const queryBuilder = this.testimonyORMRepository
+      .createQueryBuilder(alias)
+      .leftJoinAndSelect(`${alias}.user`, 'user') // Carga eager del usuario que escribió el testimonio
+      .leftJoinAndSelect('user.role_relation', 'userRole'); // Carga el rol del usuario
+
+    if (!includeDeleted) {
+      queryBuilder.andWhere(`${alias}.deleted_at IS NULL`);
+    }
+
+    return queryBuilder;
+  }
+
+  /**
+   * Busca un testimonio por su ID.
+   * @param id El ID del testimonio.
+   * @param includeDeleted Si se deben incluir testimonios marcados como eliminados.
+   * @returns La entidad Testimony o null si no se encuentra.
+   */
+  async findOneById(
+    id: string,
+    includeDeleted: boolean = false,
+  ): Promise<Testimony | null> {
+    this.logger.debug(`findOneById(): Buscando testimonio con ID: ${id}`);
+    return this.createQueryBuilderWithRelations('testimony', includeDeleted)
+      .where('testimony.id = :id', { id })
+      .getOne();
+  }
+
+  /**
+   * Busca todos los testimonios paginados, filtrados y ordenados.
+   * @param queryDto DTO con parámetros de paginación, filtro y ordenación.
+   * @returns Una promesa que resuelve a un objeto con la lista de testimonios y el total.
+   */
+  async findAllPaginated(
+    queryDto: GetTestimoniesQueryDto,
+  ): Promise<{ testimonies: Testimony[]; total: number }> {
+    this.logger.debug(
+      `findAllPaginated(): Buscando testimonios con filtros: ${JSON.stringify(
+        queryDto,
+      )}`,
+    );
+
+    // Acceder directamente a las propiedades del queryDto
+    const limit = queryDto.limit !== undefined ? queryDto.limit : 10;
+    const offset = queryDto.offset !== undefined ? queryDto.offset : 0;
+    const isApproved = queryDto.isApproved;
+    const includeDeleted =
+      queryDto.includeDeleted !== undefined ? queryDto.includeDeleted : false;
+    const orderBy =
+      queryDto.orderBy !== undefined ? queryDto.orderBy : 'created_at';
+    const order = queryDto.order !== undefined ? queryDto.order : 'DESC';
+    const userId = queryDto.userId;
+
+    const queryBuilder = this.createQueryBuilderWithRelations(
+      'testimony',
+      includeDeleted,
+    );
+
+    // Filtrar por ID de usuario si se proporciona
+    if (userId) {
+      queryBuilder.andWhere('testimony.user_id = :userId', { userId });
+    }
+
+    // Filtrar por estado de aprobación si se proporciona
+    if (typeof isApproved === 'boolean') {
+      queryBuilder.andWhere('testimony.is_approved = :isApproved', {
+        isApproved,
+      });
+    }
+
+    // Ordenación
+    if (orderBy && order) {
+      // Manejar ordenación por relaciones si es necesario
+      if (orderBy.startsWith('user.')) {
+        queryBuilder.orderBy(orderBy, order);
+      } else {
+        queryBuilder.orderBy(`testimony.${orderBy}`, order);
+      }
+    }
+
+    // Paginación
+    queryBuilder.skip(offset).take(limit);
+
+    const [testimonies, total] = await queryBuilder.getManyAndCount();
+
+    this.logger.debug(
+      `findAllPaginated(): Se encontraron ${total} testimonios.`,
+    );
+    return { testimonies, total };
+  }
+
+  /**
+   * Guarda una entidad Testimony en la base de datos.
+   * @param testimony La entidad Testimony a guardar.
+   * @returns La entidad Testimony guardada.
+   */
+  async saveTestimony(testimony: Testimony): Promise<Testimony> {
+    this.logger.log(
+      `saveTestimony(): Guardando testimonio con ID: ${
+        testimony.id || 'nuevo'
+      }`,
+    );
+    return this.testimonyORMRepository.save(testimony);
+  }
+
+  /**
+   * Crea una nueva instancia de Testimony.
+   * @param testimonyPartial Datos parciales de la entidad Testimony.
+   * @returns La nueva entidad Testimony (no guardada aún).\
+   */
+  createTestimony(testimonyPartial: Partial<Testimony>): Testimony {
+    return this.testimonyORMRepository.create(testimonyPartial);
+  }
+
+  /**
+   * Realiza un "soft delete" en un testimonio, marcándolo como eliminado lógicamente.
+   * Esto establece la columna `deleted_at` a la fecha y hora actuales.
+   * @param id El ID del testimonio a desactivar.
+   */
+  async softDeleteTestimony(id: string): Promise<void> {
+    this.logger.log(`softDeleteTestimony(): Testimonio ${id} soft-deleted.`);
+    await this.testimonyORMRepository.update(
+      { id },
+      { deleted_at: new Date() },
+    );
+  }
+
+  /**
+   * Elimina un testimonio por su ID (borrado físico).
+   * NOTA: Esto realiza un borrado físico. Úsalo con precaución.
+   * @param id El ID del testimonio a eliminar.
+   */
+  async hardDeleteTestimony(id: string): Promise<void> {
+    this.logger.warn(
+      `hardDeleteTestimony(): Eliminando físicamente el testimonio ${id}.`,
+    );
+    await this.testimonyORMRepository.delete(id);
+  }
+}

--- a/beland-backend/src/users/entities/users.entity.ts
+++ b/beland-backend/src/users/entities/users.entity.ts
@@ -28,6 +28,7 @@ import { UserAddress } from '../../user-address/entities/user-address.entity';
 import { UserCard } from '../../user-cards/entities/user-card.entity';
 import { GroupInvitation } from '../../group-invitations/entities/group-invitation.entity';
 import { WithdrawAccount } from '../../withdraw-account/entities/withdraw-account.entity';
+import { Testimony } from 'src/testimonies/entities/testimony.entity';
 
 // Definición de tipo para todos los roles válidos (importante para consistencia)
 export type ValidRoleNames =
@@ -101,8 +102,8 @@ export class User {
     eager: true,
   })
   @JoinColumn({ name: 'role_id', referencedColumnName: 'role_id' })
-  role: Role ;
-  @Column({ type: 'uuid'})
+  role: Role;
+  @Column({ type: 'uuid' })
   role_id: string; // ID del rol (FK)
 
   // ¡NUEVA RELACIÓN OneToOne con Admin!
@@ -129,6 +130,10 @@ export class User {
   // NEW: Invitations received by this user
   @OneToMany(() => GroupInvitation, (invitation) => invitation.invited_user)
   received_invitations: GroupInvitation[];
+
+  // NUEVO: Relación con Testimonios
+  @OneToMany(() => Testimony, (testimony) => testimony.user)
+  testimonies: Testimony[];
 
   @OneToMany(() => Order, (order) => order.leader)
   orders: Order[];
@@ -160,7 +165,7 @@ export class User {
   @OneToMany(() => UserCard, (card) => card.user, { cascade: true })
   cards: UserCard[];
 
-    // 🔹 Un usuario puede tener varias cuentas de retiro
+  // 🔹 Un usuario puede tener varias cuentas de retiro
   @OneToMany(() => WithdrawAccount, (withdrawAccount) => withdrawAccount.user)
   withdraw_accounts: WithdrawAccount[];
 }


### PR DESCRIPTION
Introduces the Testimonies module, including DTOs, entity, repository, service, and controller for managing user testimonies with approval and soft/hard delete logic. Integrates Testimony entity with User entity and updates app.module and users.entity.ts to support the new feature.